### PR TITLE
Migrate to Microsoft.Data.SqlClient

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ There are a few ways to transfer the data, which are exposed at `TemporaryTables
     TemporaryTablesInsertDefinition.SqlBulkCopy(Func<SqlBulkCopyOptions, SqlBulkCopyOptions>)
     ```
 
-    [SqlBulkCopy](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlbulkcopy?view=dotnet-plat-ext-5.0) type is used to transfer data to the target tables.
+    [SqlBulkCopy](https://learn.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlbulkcopy) type is used to transfer data to the target tables.
 
 4. **BCP** (Work in progress):
     Uses [BCP utility](https://docs.microsoft.com/en-us/sql/tools/bcp-utility?view=sql-server-ver15) to copy the data.

--- a/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
+++ b/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
+++ b/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.41" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/samples/Reseed.Samples.NUnit/SampleFixture.cs
+++ b/samples/Reseed.Samples.NUnit/SampleFixture.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 using NUnit.Framework;
 

--- a/samples/Reseed.Samples.NUnit/SqlServerContainer.cs
+++ b/samples/Reseed.Samples.NUnit/SqlServerContainer.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using DbUp;
 using DbUp.Engine;
+using Microsoft.Data.SqlClient;
 using Testcontainers.MsSql;
 
 namespace Reseed.Samples.NUnit
@@ -22,7 +22,8 @@ namespace Reseed.Samples.NUnit
 			{
 				var connectionString = new SqlConnectionStringBuilder(server.GetConnectionString())
 				{
-					InitialCatalog = DatabaseName
+					InitialCatalog = DatabaseName,
+					TrustServerCertificate = true
 				};
 
 				return connectionString.ConnectionString;

--- a/src/Reseed/Configuration/TemporaryTables/TemporaryTablesInsertDefinition.cs
+++ b/src/Reseed/Configuration/TemporaryTables/TemporaryTablesInsertDefinition.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using JetBrains.Annotations;
 using Reseed.Schema;
 

--- a/src/Reseed/Configuration/TemporaryTables/TemporaryTablesInsertSqlBulkCopyDefinition.cs
+++ b/src/Reseed/Configuration/TemporaryTables/TemporaryTablesInsertSqlBulkCopyDefinition.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Reseed.Utils;
 
 namespace Reseed.Configuration.TemporaryTables

--- a/src/Reseed/Execution/SeedActionExecutor.cs
+++ b/src/Reseed/Execution/SeedActionExecutor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using JetBrains.Annotations;
 using Reseed.Generation;
 using Reseed.Ordering;

--- a/src/Reseed/Generation/ISeedAction.cs
+++ b/src/Reseed/Generation/ISeedAction.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using JetBrains.Annotations;
 using Reseed.Ordering;

--- a/src/Reseed/Generation/TemporaryTables/TemporaryTablesSqlBulkCopyGenerator.cs
+++ b/src/Reseed/Generation/TemporaryTables/TemporaryTablesSqlBulkCopyGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using JetBrains.Annotations;
 using Reseed.Configuration.TemporaryTables;

--- a/src/Reseed/Reseed.csproj
+++ b/src/Reseed/Reseed.csproj
@@ -6,6 +6,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="JetBrains.Annotations" Version="2020.3.0" PrivateAssets="all" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" />
 	</ItemGroup>
 </Project>

--- a/src/Reseed/Reseeder.cs
+++ b/src/Reseed/Reseeder.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Data.SqlClient;
 using Reseed.Configuration;
 using Reseed.Data;
 using Reseed.Execution;

--- a/src/Reseed/ReseederExtensions.cs
+++ b/src/Reseed/ReseederExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using JetBrains.Annotations;
+using Microsoft.Data.SqlClient;
 using Reseed.Configuration;
 using Reseed.Generation;
 using Reseed.Ordering;

--- a/src/Reseed/Schema/Providers/MsSqlSchemaProvider.cs
+++ b/src/Reseed/Schema/Providers/MsSqlSchemaProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using JetBrains.Annotations;
 using Reseed.Graphs;
 using Testing.Common.Api.Schema;

--- a/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
+++ b/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using Reseed.Utils;
 using static Reseed.Ordering.OrderedItem;

--- a/src/Reseed/Schema/SchemaProvider.cs
+++ b/src/Reseed/Schema/SchemaProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using JetBrains.Annotations;
 using Reseed.Schema.Providers;
 

--- a/src/Reseed/Utils/SqlDataReaderExtensions.cs
+++ b/src/Reseed/Utils/SqlDataReaderExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Reseed.Utils
 {

--- a/tests/Reseed.Tests.Integration/Core/SqlEngine.cs
+++ b/tests/Reseed.Tests.Integration/Core/SqlEngine.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 
 namespace Reseed.Tests.Integration.Core

--- a/tests/Reseed.Tests.Integration/Core/SqlServerContainer.cs
+++ b/tests/Reseed.Tests.Integration/Core/SqlServerContainer.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using DbUp;
 using DbUp.Engine;
 using DbUp.Helpers;
+using Microsoft.Data.SqlClient;
 using Testcontainers.MsSql;
 
 namespace Reseed.Tests.Integration.Core
@@ -24,7 +24,8 @@ namespace Reseed.Tests.Integration.Core
 			{
 				var connectionString = new SqlConnectionStringBuilder(server.GetConnectionString())
 				{
-					InitialCatalog = DatabaseName
+					InitialCatalog = DatabaseName,
+					TrustServerCertificate = true
 				};
 
 				return connectionString.ConnectionString;

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
+    <PackageReference Include="dbup-sqlserver" Version="5.0.41" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" />

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- replace `System.Data.SqlClient` with `Microsoft.Data.SqlClient` 5.2.3 across the library, samples, and integration tests
- upgrade `dbup-sqlserver` to 5.0.41 so test database setup also uses Microsoft.Data.SqlClient
- trust the self-signed certificates used by local SQL Server test containers
- update the `SqlBulkCopy` documentation link

## Validation
- `dotnet restore Reseed.sln --nologo --verbosity minimal`
- `dotnet build Reseed.sln --no-restore --configuration Release --nologo --verbosity minimal`
- `dotnet test Reseed.sln --no-build --configuration Release --nologo --verbosity minimal`
- 89 tests passed

Build retains the existing `NU1903` warning for transitive `Newtonsoft.Json` 9.0.1.