### PR TITLE
Migrate test projects to .NET 10

### DIFF
--- a/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
+++ b/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- retarget the NUnit sample and integration test projects from `netcoreapp3.1` to `net10.0`
- keep the core library on `netstandard2.0` and retain all existing package versions, including `System.Data.SqlClient` and `DotNet.Testcontainers` 1.5.0
- build on the lock-file cleanup merged through #41

## Validation
- `dotnet restore Reseed.sln --no-cache --verbosity minimal`
- `dotnet build Reseed.sln --no-restore --configuration Release --verbosity minimal`
- sample tests: 2/2 blocked during container startup by `System.InvalidOperationException: cannot hijack chunked or content length stream`
- integration tests: 87/87 blocked during container startup by the same exception

Docker Desktop 4.83.0 / Engine 29.6.2 is healthy and responds to CLI operations. The failure is the known legacy `DotNet.Testcontainers` 1.5.0 incompatibility with modern Docker/.NET HTTP handling, not a .NET 10 compilation or test-discovery failure. No Testcontainers upgrade is included.