### PR TITLE
Upgrade Testcontainers for .NET

### DIFF
--- a/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
+++ b/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.5.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />

--- a/samples/Reseed.Samples.NUnit/SqlServerContainer.cs
+++ b/samples/Reseed.Samples.NUnit/SqlServerContainer.cs
@@ -1,20 +1,33 @@
-﻿using System;
+using System;
+using System.Data.SqlClient;
 using System.Threading.Tasks;
 using DbUp;
 using DbUp.Engine;
-using DotNet.Testcontainers.Containers.Builders;
-using DotNet.Testcontainers.Containers.Configurations.Abstractions;
-using DotNet.Testcontainers.Containers.Modules.Databases;
-using DotNet.Testcontainers.Containers.WaitStrategies;
+using Testcontainers.MsSql;
 
 namespace Reseed.Samples.NUnit
 {
 	public class SqlServerContainer: IAsyncDisposable
 	{
-		private readonly string scriptsFolder;
-		private readonly MsSqlTestcontainer server;
+		private const string DatabaseName = "MsSqlContainerDb";
+		private const string Password = "!A1B2c3d4_";
+		private const string ServerImage = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
 
-		public string ConnectionString => server.ConnectionString;
+		private readonly string scriptsFolder;
+		private readonly MsSqlContainer server;
+
+		public string ConnectionString
+		{
+			get
+			{
+				var connectionString = new SqlConnectionStringBuilder(server.GetConnectionString())
+				{
+					InitialCatalog = DatabaseName
+				};
+
+				return connectionString.ConnectionString;
+			}
+		}
 
 		public SqlServerContainer(string scriptsFolder)
 		{
@@ -25,9 +38,9 @@ namespace Reseed.Samples.NUnit
 		public async Task StartAsync()
 		{
 			await StartServerAsync();
-			EnsureDatabase.For.SqlDatabase(server.ConnectionString);
+			EnsureDatabase.For.SqlDatabase(ConnectionString);
 
-			var migrationResult = MigrateDatabase(server.ConnectionString, scriptsFolder);
+			var migrationResult = MigrateDatabase(ConnectionString, scriptsFolder);
 			if (!migrationResult.Successful)
 			{
 				throw new InvalidOperationException("Can't apply database migrations", migrationResult.Error);
@@ -51,10 +64,9 @@ namespace Reseed.Samples.NUnit
 		public ValueTask DisposeAsync() => 
 			this.server.DisposeAsync();
 
-		private static MsSqlTestcontainer CreateDatabaseContainer() =>
-			new TestcontainersBuilder<MsSqlTestcontainer>()
-				.WithDatabase(new DbContainerConfiguration("MsSqlContainerDb", "!A1B2c3d4_"))
-				.WithName("sql-db")
+		private static MsSqlContainer CreateDatabaseContainer() =>
+			new MsSqlBuilder(ServerImage)
+				.WithPassword(Password)
 				.Build();
 
 		private static DatabaseUpgradeResult MigrateDatabase(string connectionString, string scriptsPath)
@@ -68,32 +80,5 @@ namespace Reseed.Samples.NUnit
 			
 			return upgrade.PerformUpgrade();
 		}
-	}
-
-	public sealed class DbContainerConfiguration : TestcontainerDatabaseConfiguration
-	{
-		private const string ServerImage = "mcr.microsoft.com/mssql/server:latest";
-		private const string PasswordKey = "SA_PASSWORD";
-		private const string EulaKey = "ACCEPT_EULA";
-		private const int ServerPort = 1433;
-
-		public DbContainerConfiguration(string database, string password) : base(ServerImage, ServerPort)
-		{
-			Environments[EulaKey] = "Y";
-			Password = password;
-			Database = database;
-		}
-
-		public override string Username => "sa";
-
-		public override string Password
-		{
-			get => Environments[PasswordKey];
-			set => Environments[PasswordKey] = value;
-		}
-
-		public override IWaitForContainerOS WaitStrategy => Wait
-			.ForUnixContainer()
-			.UntilPortIsAvailable(ServerPort);
 	}
 }

--- a/tests/Reseed.Tests.Integration/Core/SqlServerContainer.cs
+++ b/tests/Reseed.Tests.Integration/Core/SqlServerContainer.cs
@@ -1,22 +1,35 @@
-﻿using System;
+using System;
+using System.Data.SqlClient;
 using System.Threading.Tasks;
 using DbUp;
 using DbUp.Engine;
 using DbUp.Helpers;
-using DotNet.Testcontainers.Containers.Builders;
-using DotNet.Testcontainers.Containers.Configurations.Abstractions;
-using DotNet.Testcontainers.Containers.Modules.Databases;
-using DotNet.Testcontainers.Containers.WaitStrategies;
+using Testcontainers.MsSql;
 
 namespace Reseed.Tests.Integration.Core
 {
 	public sealed class SqlServerContainer: IAsyncDisposable
 	{
+		private const string DatabaseName = "MsSqlContainerDb";
+		private const string Password = "!A1B2c3d4_";
+		private const string ServerImage = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
+
 		private readonly string scriptsFolder;
 		private readonly Func<string, bool> scriptFilter;
-		private readonly MsSqlTestcontainer server;
+		private readonly MsSqlContainer server;
 
-		public string ConnectionString => server.ConnectionString;
+		public string ConnectionString
+		{
+			get
+			{
+				var connectionString = new SqlConnectionStringBuilder(server.GetConnectionString())
+				{
+					InitialCatalog = DatabaseName
+				};
+
+				return connectionString.ConnectionString;
+			}
+		}
 
 		public SqlServerContainer(string scriptsFolder)
 			: this(scriptsFolder, _ => true)
@@ -33,10 +46,10 @@ namespace Reseed.Tests.Integration.Core
 		public async Task StartAsync()
 		{
 			await StartServerAsync();
-			EnsureDatabase.For.SqlDatabase(server.ConnectionString);
+			EnsureDatabase.For.SqlDatabase(ConnectionString);
 
 			var migrationResult = MigrateDatabase(
-				server.ConnectionString,
+				ConnectionString,
 				scriptsFolder,
 				scriptFilter);
 
@@ -63,10 +76,9 @@ namespace Reseed.Tests.Integration.Core
 		public ValueTask DisposeAsync() => 
 			this.server.DisposeAsync();
 
-		private static MsSqlTestcontainer CreateDatabaseContainer() =>
-			new TestcontainersBuilder<MsSqlTestcontainer>()
-				.WithDatabase(new DbContainerConfiguration("MsSqlContainerDb", "!A1B2c3d4_"))
-				.WithName($"sql-db_{Guid.NewGuid()}")
+		private static MsSqlContainer CreateDatabaseContainer() =>
+			new MsSqlBuilder(ServerImage)
+				.WithPassword(Password)
 				.Build();
 
 		private static DatabaseUpgradeResult MigrateDatabase(
@@ -84,32 +96,5 @@ namespace Reseed.Tests.Integration.Core
 			
 			return upgrade.PerformUpgrade();
 		}
-	}
-
-	public sealed class DbContainerConfiguration : TestcontainerDatabaseConfiguration
-	{
-		private const string ServerImage = "mcr.microsoft.com/mssql/server:latest";
-		private const string PasswordKey = "SA_PASSWORD";
-		private const string EulaKey = "ACCEPT_EULA";
-		private const int ServerPort = 1433;
-
-		public DbContainerConfiguration(string database, string password) : base(ServerImage, ServerPort)
-		{
-			Environments[EulaKey] = "Y";
-			Password = password;
-			Database = database;
-		}
-
-		public override string Username => "sa";
-
-		public override string Password
-		{
-			get => Environments[PasswordKey];
-			set => Environments[PasswordKey] = value;
-		}
-
-		public override IWaitForContainerOS WaitStrategy => Wait
-			.ForUnixContainer()
-			.UntilPortIsAvailable(ServerPort);
 	}
 }

--- a/tests/Reseed.Tests.Integration/GenerationValidationTests.cs
+++ b/tests/Reseed.Tests.Integration/GenerationValidationTests.cs
@@ -30,7 +30,7 @@ namespace Reseed.Tests.Integration
 		// when entities load don't match any of the existing tables
 		public Task ShouldFailGracefully_UnknownEntity() =>
 			AssertSeedFails(ex => ex.Message.StartsWith(
-				"Some of the entities found don't have matching database tables. " +
+				"Some of the entities provided don't have matching database tables. " +
 				"Make sure that names are correct and expected."));
 
 		private Task AssertSeedFails(Expression<Func<Exception, bool>> assertError) =>

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="4.5.0" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.5.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />


### PR DESCRIPTION
## Summary

- upgrade the legacy `DotNet.Testcontainers` 1.5.0 dependency to `Testcontainers.MsSql` 4.13.0
- migrate both SQL Server fixtures to `MsSqlBuilder` and `MsSqlContainer`
- preserve the `MsSqlContainerDb` connection behavior while using the module's SQL-aware readiness strategy, random host ports, generated container names, and async disposal
- align the unknown-entity integration assertion with the library's existing `entities provided` error wording

## Scope

This branch is based on the latest `main`, including the .NET 10 test-project migration. The Reseed library remains on `netstandard2.0`. This PR does not include the Microsoft.Data.SqlClient migration from PR #39.

NuGet lock files are not part of this PR because they were removed repository-wide.

## Validation

- both affected projects build successfully
- sample Docker suite: 2 passed, 0 failed
- integration Docker suite before correcting the baseline assertion: 86 passed, 1 failed
- corrected `ShouldFailGracefully_UnknownEntity` Docker test: 1 passed, 0 failed

The Docker-backed runs completed without the legacy Docker.DotNet container Attach failure.