### PR TITLE
Upgrade NUnit dependencies

### DIFF
--- a/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
+++ b/samples/Reseed.Samples.NUnit/Reseed.Samples.NUnit.csproj
@@ -7,9 +7,13 @@
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="5.0.41" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" />
   </ItemGroup>
 

--- a/samples/Reseed.Samples.NUnit/SampleFixture.cs
+++ b/samples/Reseed.Samples.NUnit/SampleFixture.cs
@@ -25,11 +25,11 @@ namespace Reseed.Samples.NUnit
 			// We don't need to do any User table initialization manually.
 			// Reseeder, invoked in the TestFixtureBase type, will take care of that
 			// And insert all the User rows described at 'Data/Users.xml' and in Inline csharp provider.
-			Assert.AreEqual(UsersCount, await GetUsersCount());
+			Assert.That(await GetUsersCount(), Is.EqualTo(UsersCount));
 
 			// Executing an action with mutation, which won't be noticed in the rest of the tests.
 			await ExecuteNonQueryAsync("DELETE FROM [dbo].[User]");
-			Assert.AreEqual(0, await GetUsersCount());
+			Assert.That(await GetUsersCount(), Is.EqualTo(0));
 		}
 
 		[Test]
@@ -38,11 +38,11 @@ namespace Reseed.Samples.NUnit
 		{
 			// In spite of the previous test, which might have deleted all the data from User table,
 			// we have the expected rows count here.
-			Assert.AreEqual(UsersCount, await GetUsersCount());
+			Assert.That(await GetUsersCount(), Is.EqualTo(UsersCount));
 
 			// Executing an action with mutation, which won't be noticed in the rest of the tests.
 			await ExecuteNonQueryAsync("INSERT INTO [dbo].[User] VALUES ('Test', 'Test')");
-			Assert.AreEqual(UsersCount + 1, await GetUsersCount());
+			Assert.That(await GetUsersCount(), Is.EqualTo(UsersCount + 1));
 		}
 
 		private static Task<int> GetUsersCount() => 

--- a/samples/Reseed.Samples.NUnit/TestFixtureBase.cs
+++ b/samples/Reseed.Samples.NUnit/TestFixtureBase.cs
@@ -16,7 +16,7 @@ namespace Reseed.Samples.NUnit
 	// It will make sure that test database is initialized and cleaned up just once as well as
 	// insert and delete test data before/after each test run. 
 	[TestFixture]
-	public class TestFixtureBase
+	public abstract class TestFixtureBase
 	{
 		private static readonly TestDatabase Database = new(
 			GetRelativePath("Migrations"),

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -7,10 +7,14 @@
   <ItemGroup>
     <PackageReference Include="dbup-sqlserver" Version="5.0.41" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Reseed.Tests.Integration/SingleTableTests.cs
+++ b/tests/Reseed.Tests.Integration/SingleTableTests.cs
@@ -44,7 +44,7 @@ namespace Reseed.Tests.Integration
 				this,
 				this.createMode,
 				sql => sql.ExecuteNonQueryAsync("DELETE FROM [dbo].[User]"), 
-				async sql => Assert.AreEqual(userCount, await GetUsersCount(sql)));
+				async sql => Assert.That(await GetUsersCount(sql), Is.EqualTo(userCount)));
 			
 			static Task<int> GetUsersCount(SqlEngine sqlEngine) =>
 				sqlEngine.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM [dbo].[User]");

--- a/tests/Reseed.Tests.Integration/SingleTableWithForeignKeyTests.cs
+++ b/tests/Reseed.Tests.Integration/SingleTableWithForeignKeyTests.cs
@@ -53,7 +53,7 @@ namespace Reseed.Tests.Integration
 				this,
 				this.createMode,
 				sql => sql.ExecuteNonQueryAsync("DELETE FROM [dbo].[User]"), 
-				async sql => Assert.AreEqual(userCount, await GetUsersCount(sql)));
+				async sql => Assert.That(await GetUsersCount(sql), Is.EqualTo(userCount)));
 
 			static Task<int> GetUsersCount(SqlEngine sqlEngine) =>
 				sqlEngine.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM [dbo].[User]");


### PR DESCRIPTION
## Summary
- upgrade NUnit and the NUnit test adapter to the latest stable releases
- upgrade Microsoft.NET.Test.Sdk and add NUnit.Analyzers
- migrate classic assertions to NUnit 4 constraint assertions
- resolve the new base-fixture analyzer diagnostic

## Validation
- sample NUnit tests pass
- integration test discovery succeeds for all 87 tests
- full integration run reached 72 passing tests; 15 failed because SQL Server Testcontainers exited during startup