### PR TITLE
Expose custom table extensions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -426,15 +426,24 @@ TBD
 
 # Data Extension
 
-Reseed is able to extend the provided data for any `IDataProvider` instance before generating the insertion scripts. 
+Reseed is able to extend the provided data for any `IDataProvider` instance before generating the insertion scripts.
 
-The only extension available for now is identity columns value generation. If Reseed finds an identity column without a value specified, it will generate a value for it automatically. If such behavior isn't desired, use `ReseedOptions.DataExtensionOptions` to disable it.
+The built-in extension generates missing identity column values automatically. If such behavior isn't desired, use `ReseederOptions.ExtensionOptions` to disable it.
 
 ```csharp
-class DataExtensionOptions 
-{
-    bool GenerateIdentityValues;
-}
+var options = new DataExtensionOptions(generateIdentityValues: false);
+```
+
+Custom `ITableExtension` implementations can also be provided through `DataExtensionOptions`. They run in the order provided, after built-in extensions.
+
+```csharp
+var options = new ReseederOptions(
+    validateData: true,
+    new DataExtensionOptions(
+        generateIdentityValues: true,
+        new ITableExtension[] { new CustomTableExtension() }));
+
+var reseeder = new Reseeder(options);
 ```
 
 # Data validation

--- a/src/Reseed/Extension/TableExtender.cs
+++ b/src/Reseed/Extension/TableExtender.cs
@@ -34,12 +34,15 @@ namespace Reseed.Extension
 				extensions.Add(IdentityGeneratorTableExtension.Instance);
 			}
 
+			extensions.AddRange(options.CustomTableExtensions);
 			return extensions.ToArray();
 		}
 	}
 
+	[PublicAPI]
 	public interface ITableExtension
 	{
-		Table Extend(Table table);
+		[NotNull]
+		Table Extend([NotNull] Table table);
 	}
 }

--- a/src/Reseed/ReseederOptions.cs
+++ b/src/Reseed/ReseederOptions.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
+using Reseed.Extension;
 
 namespace Reseed
 {
@@ -26,10 +29,26 @@ namespace Reseed
 	public sealed class DataExtensionOptions
 	{
 		public readonly bool GenerateIdentityValues;
+		public readonly IReadOnlyCollection<ITableExtension> CustomTableExtensions;
 
 		public DataExtensionOptions(bool generateIdentityValues)
+			: this(generateIdentityValues, Array.Empty<ITableExtension>())
 		{
+		}
+
+		public DataExtensionOptions(
+			bool generateIdentityValues,
+			[NotNull] IReadOnlyCollection<ITableExtension> customTableExtensions)
+		{
+			if (customTableExtensions == null)
+				throw new ArgumentNullException(nameof(customTableExtensions));
+			if (customTableExtensions.Any(extension => extension == null))
+				throw new ArgumentException(
+					"Custom table extensions cannot contain null values.",
+					nameof(customTableExtensions));
+
 			GenerateIdentityValues = generateIdentityValues;
+			CustomTableExtensions = customTableExtensions.ToArray();
 		}
 	}
 }

--- a/tests/Reseed.Tests.Integration/CustomTableExtensionTests.cs
+++ b/tests/Reseed.Tests.Integration/CustomTableExtensionTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Reseed.Extension;
+using Reseed.Generation.Schema;
+using Reseed.Tests.Integration.Core;
+
+namespace Reseed.Tests.Integration
+{
+	[Parallelizable(ParallelScope.Fixtures)]
+	public sealed class CustomTableExtensionTests : TestFixtureBase
+	{
+		[Test]
+		public async Task ShouldApplyCustomTableExtension()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var reseeder = new Reseeder(new ReseederOptions(
+				true,
+				new DataExtensionOptions(
+					true,
+					new[] { new UserNameTableExtension() })));
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				SeedModes.BasicScriptPreferTruncate(
+					Conventional.CreateConventionalDataProvider(this)));
+
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+
+			var sqlEngine = new SqlEngine(database.ConnectionString);
+			var customNames = await sqlEngine.ExecuteScalarAsync<int>(
+				"SELECT COUNT(1) FROM [dbo].[User] WHERE FirstName = 'Custom'");
+			Assert.That(customNames, Is.EqualTo(1));
+		}
+
+		private sealed class UserNameTableExtension : ITableExtension
+		{
+			public Table Extend(Table table) =>
+				table.MapRows(row =>
+				{
+					if (row.GetValue("Id") == null)
+						throw new InvalidOperationException(
+							"Built-in extensions should run before custom extensions.");
+
+					return row.WithValue("FirstName", "Custom");
+				});
+		}
+	}
+}

--- a/tests/Reseed.Tests.Integration/Data/CustomTableExtensionTests/ShouldApplyCustomTableExtension.sql
+++ b/tests/Reseed.Tests.Integration/Data/CustomTableExtensionTests/ShouldApplyCustomTableExtension.sql
@@ -1,0 +1,6 @@
+CREATE TABLE [User] (
+	Id int NOT NULL IDENTITY(1, 1) PRIMARY KEY,
+	FirstName nvarchar(100) NOT NULL,
+	LastName nvarchar(100) NOT NULL,
+	Age int NULL
+)

--- a/tests/Reseed.Tests.Integration/Data/CustomTableExtensionTests/ShouldApplyCustomTableExtension.xml
+++ b/tests/Reseed.Tests.Integration/Data/CustomTableExtensionTests/ShouldApplyCustomTableExtension.xml
@@ -1,0 +1,7 @@
+<Users>
+    <User>
+        <FirstName>John</FirstName>
+        <LastName>Doe</LastName>
+        <Age>23</Age>
+    </User>
+</Users>

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -79,6 +79,12 @@
     <None Update="Data\GenerationValidationTests\03_ShouldFailGracefully_UnknownEntity.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Data\CustomTableExtensionTests\ShouldApplyCustomTableExtension.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\CustomTableExtensionTests\ShouldApplyCustomTableExtension.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- expose custom `ITableExtension` registration through `DataExtensionOptions`
- run custom extensions after built-in table extensions in registration order
- document the API and cover custom row transformations with an integration test