### PR TITLE
Add XML value transformers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,12 +326,30 @@ Use `DataProviders.Xml` to use this approach.
 DataProviders.Xml(string);
 DataProviders.Xml(string, Func<string, bool>);
 DataProviders.Xml(string, string, Func<string, bool>);
+DataProviders.Xml(string, string, Func<string, bool>,
+    IReadOnlyCollection<Func<XmlValueContext, string, string>>);
 ```
 
 It's possible to control from what location data should be read and what files to read:
 - you need to specify a root folder, which is to be scanned recursively;
 - you could specify file name pattern to use only files, which match it(see [Directory.EnumerateFiles](https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratefiles?view=net-5.0#System_IO_Directory_EnumerateFiles_System_String_System_String_) for supported pattern features);
 - you could filter your files additionally by providing a `Func<string, bool>` predicate to check each file's name.
+
+The most advanced overload accepts value transformers. They are applied in collection order, and each receives `XmlValueContext` metadata plus the previous transformer's result. The context exposes the source `FilePath`, XML `EntityName`, and `PropertyName`:
+
+```csharp
+var dataProvider = DataProviders.Xml(
+    @".\Data",
+    "*.xml",
+    _ => true,
+    new Func<XmlValueContext, string, string>[]
+    {
+        (_, value) => value.Trim(),
+        (context, value) => context.PropertyName == "Email"
+            ? value.ToLowerInvariant()
+            : value
+    });
+```
 
 Rules to describe the data are simple:
 - Each row should be represented as xml element with nested elements for each column. 

--- a/src/Reseed/Data/DataProviders.cs
+++ b/src/Reseed/Data/DataProviders.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Reseed.Data.Providers;
 using Reseed.Data.Providers.FileSystem;
@@ -20,6 +22,27 @@ namespace Reseed.Data
 			[NotNull] string filePattern,
 			[NotNull] Func<string, bool> fileFilter) =>
 			new XmlDataProvider(dataFolder, filePattern, fileFilter);
+
+		public static IDataProvider Xml(
+			[NotNull] string dataFolder,
+			[NotNull] string filePattern,
+			[NotNull] Func<string, bool> fileFilter,
+			[NotNull] IReadOnlyCollection<Func<XmlValueContext, string, string>> valueTransformers)
+		{
+			if (valueTransformers == null) throw new ArgumentNullException(nameof(valueTransformers));
+			if (valueTransformers.Any(t => t == null))
+			{
+				throw new ArgumentException(
+					"Value cannot contain null transformers.",
+					nameof(valueTransformers));
+			}
+
+			return new XmlDataProvider(
+				dataFolder,
+				filePattern,
+				fileFilter,
+				valueTransformers.ToArray());
+		}
 
 		public static IDataProvider Inline(
 			[NotNull] Func<InlineDataProviderBuilder, IDataProvider> setup)

--- a/src/Reseed/Data/Providers/FileSystem/XmlDataProvider.cs
+++ b/src/Reseed/Data/Providers/FileSystem/XmlDataProvider.cs
@@ -8,20 +8,53 @@ using Reseed.Utils;
 
 namespace Reseed.Data.Providers.FileSystem
 {
+	public sealed class XmlValueContext
+	{
+		public readonly string FilePath;
+		public readonly string EntityName;
+		public readonly string PropertyName;
+
+		public XmlValueContext(
+			[NotNull] string filePath,
+			[NotNull] string entityName,
+			[NotNull] string propertyName)
+		{
+			this.FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+			this.EntityName = entityName ?? throw new ArgumentNullException(nameof(entityName));
+			this.PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
+		}
+	}
+
 	internal sealed class XmlDataProvider: IVerboseDataProvider
 	{
 		private readonly string dataFolder;
 		private readonly string filePattern;
 		private readonly Func<string, bool> fileFilter;
+		private readonly IReadOnlyCollection<Func<XmlValueContext, string, string>> valueTransformers;
 
 		public XmlDataProvider(
 			[NotNull] string dataFolder,
 			[NotNull] string filePattern,
 			[NotNull] Func<string, bool> fileFilter)
+			: this(
+				dataFolder,
+				filePattern,
+				fileFilter,
+				Array.Empty<Func<XmlValueContext, string, string>>())
+		{
+		}
+
+		public XmlDataProvider(
+			[NotNull] string dataFolder,
+			[NotNull] string filePattern,
+			[NotNull] Func<string, bool> fileFilter,
+			[NotNull] IReadOnlyCollection<Func<XmlValueContext, string, string>> valueTransformers)
 		{
 			this.dataFolder = dataFolder ?? throw new ArgumentNullException(nameof(dataFolder));
 			this.filePattern = filePattern ?? throw new ArgumentNullException(nameof(filePattern));
 			this.fileFilter = fileFilter ?? throw new ArgumentNullException(nameof(fileFilter));
+			this.valueTransformers = valueTransformers ??
+				throw new ArgumentNullException(nameof(valueTransformers));
 		}
 
 		public VerboseDataProviderResult GetEntitiesDetailed()
@@ -59,7 +92,7 @@ namespace Reseed.Data.Providers.FileSystem
 		public IReadOnlyCollection<Entity> GetEntities() => 
 			GetEntitiesDetailed().Entities;
 
-		private static Entity[] ReadFile([NotNull] string path)
+		private Entity[] ReadFile([NotNull] string path)
 		{
 			var file = new DataFile(path);
 			var rootElements = XDocument.Load(path)
@@ -87,10 +120,11 @@ namespace Reseed.Data.Providers.FileSystem
 				.ToArray();
 		}
 
-		private static Entity ParseEntity(DataFile origin, XElement element)
+		private Entity ParseEntity(DataFile origin, XElement element)
 		{
 			AssertNoAttributes(origin, element);
 
+			var entityName = element.Name.LocalName;
 			var propertyElements = element.Elements().ToArray();
 			if (propertyElements.Length == 0)
 			{
@@ -102,15 +136,40 @@ namespace Reseed.Data.Providers.FileSystem
 
 			return new Entity(
 				origin,
-				element.Name.LocalName,
-				propertyElements.Select(e => ParseProperty(origin, e)).ToArray());
+				entityName,
+				propertyElements.Select(e => ParseProperty(origin, entityName, e)).ToArray());
 		}
 
-		private static Property ParseProperty(DataFile origin, XElement element)
+		private Property ParseProperty(DataFile origin, string entityName, XElement element)
 		{
 			AssertNoAttributes(origin, element);
 			AssertNoDescendants(origin, element);
-			return new Property(element.Name.LocalName, element.Value);
+			var propertyName = element.Name.LocalName;
+
+			if (this.valueTransformers.Count == 0)
+				return new Property(propertyName, element.Value);
+
+			var context = new XmlValueContext(
+				origin.FilePath,
+				entityName,
+				propertyName);
+			var transformedValue = this.valueTransformers.Aggregate(
+				element.Value,
+				(value, transformer) =>
+				{
+					var result = transformer(context, value);
+					if (result == null)
+					{
+						throw BuildDocumentError(
+							origin,
+							"XML value transformer returned null for property element " +
+							$"'{propertyName}' in entity element '{entityName}'");
+					}
+
+					return result;
+				});
+
+			return new Property(propertyName, transformedValue);
 		}
 
 		private static void AssertNoDescendants(DataFile dataFile, XElement element)


### PR DESCRIPTION
## Summary
- add a public `XmlValueTransformer` delegate and `XmlValueContext` metadata model
- add transformer-aware `DataProviders.Xml` overloads while preserving existing behavior
- transform each XML property exactly once and report null transformer results clearly
- document usage and cover metadata, ordering, defaults, validation, and exception propagation

## Tests
- `dotnet test .\tests\Reseed.Tests.Integration\Reseed.Tests.Integration.csproj --filter FullyQualifiedName~XmlDataProviderTests --no-restore`
- `dotnet build .\src\Reseed\Reseed.csproj --no-restore`