### PR TITLE
Bump package version to 0.1.14

### DIFF
--- a/publish.cmd
+++ b/publish.cmd
@@ -3,7 +3,7 @@ SET "src=%~dp0src"
 SET "props=%~dp0publish.props"
 SET "key=%NUGET_RESEED_KEY%"
 SET "outpath=%src%\Reseed\bin\publish"
-SET version=0.1.12
+SET version=0.1.14
 
 if exist %outpath%\ (
     rmdir /s /q %outpath%


### PR DESCRIPTION
## Summary
- bump the NuGet package version from 0.1.12 to 0.1.14
- publish `Reseed` 0.1.14 and its symbols package to NuGet.org

## Validation
- `publish.cmd` packed and pushed `Reseed.0.1.14.nupkg`
- `publish.cmd` packed and pushed `Reseed.0.1.14.snupkg`