### PR TITLE
Support XML Schema durations

### DIFF
--- a/publish.cmd
+++ b/publish.cmd
@@ -3,7 +3,7 @@ SET "src=%~dp0src"
 SET "props=%~dp0publish.props"
 SET "key=%NUGET_RESEED_KEY%"
 SET "outpath=%src%\Reseed\bin\publish"
-SET version=0.1.15
+SET version=0.2.0
 
 if exist %outpath%\ (
     rmdir /s /q %outpath%

--- a/readme.md
+++ b/readme.md
@@ -335,21 +335,8 @@ It's possible to control from what location data should be read and what files t
 - you could specify file name pattern to use only files, which match it(see [Directory.EnumerateFiles](https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratefiles?view=net-5.0#System_IO_Directory_EnumerateFiles_System_String_System_String_) for supported pattern features);
 - you could filter your files additionally by providing a `Func<string, bool>` predicate to check each file's name.
 
-The most advanced overload accepts value transformers. They are applied in collection order, and each receives `XmlValueContext` metadata plus the previous transformer's result. The context exposes the source `FilePath`, XML `EntityName`, and `PropertyName`:
-
-```csharp
-var dataProvider = DataProviders.Xml(
-    @".\Data",
-    "*.xml",
-    _ => true,
-    new Func<XmlValueContext, string, string>[]
-    {
-        (_, value) => value.Trim(),
-        (context, value) => context.PropertyName == "Email"
-            ? value.ToLowerInvariant()
-            : value
-    });
-```
+Built-in XML provider also supports value transformation as `(XmlValueContext, string) -> string` with some transformations available out-of-the-box under `XmlValueTransformers`.
+- `XmlValueTransformers.Duration` converts valid XML Schema durations, such as `PT1H30M`, to the invariant `TimeSpan` format.
 
 Rules to describe the data are simple:
 - Each row should be represented as xml element with nested elements for each column. 

--- a/src/Reseed/Data/Providers/FileSystem/XmlDataProvider.cs
+++ b/src/Reseed/Data/Providers/FileSystem/XmlDataProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Reseed/Data/Providers/FileSystem/XmlValueTransformers.cs
+++ b/src/Reseed/Data/Providers/FileSystem/XmlValueTransformers.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+using System.Xml;
+
+namespace Reseed.Data.Providers.FileSystem
+{
+	public static class XmlValueTransformers
+	{
+		public static readonly Func<XmlValueContext, string, string> Duration =
+			(_, value) =>
+			{
+				if (string.IsNullOrEmpty(value) ||
+				    value[0] != 'P' && !(value[0] == '-' && value.Length > 1 && value[1] == 'P'))
+				{
+					return value;
+				}
+
+				try
+				{
+					return XmlConvert
+						.ToTimeSpan(value)
+						.ToString("c", CultureInfo.InvariantCulture);
+				}
+				catch (FormatException)
+				{
+					return value;
+				}
+			};
+	}
+}

--- a/tests/Reseed.Tests.Integration/XmlValueTransformersTests.cs
+++ b/tests/Reseed.Tests.Integration/XmlValueTransformersTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using Reseed.Data.Providers.FileSystem;
+
+namespace Reseed.Tests.Integration
+{
+	public sealed class XmlValueTransformersTests
+	{
+		[TestCase("P2DT3H4M5.678S", "2.03:04:05.6780000")]
+		[TestCase("-PT1H30M", "-01:30:00")]
+		[TestCase("PT is ordinary text", "PT is ordinary text")]
+		public void ShouldConvertXmlSchemaDurationToTimeSpan(string value, string expected)
+		{
+			var context = new XmlValueContext("data.xml", "Entity", "Value");
+
+			var result = XmlValueTransformers.Duration(context, value);
+
+			Assert.That(result, Is.EqualTo(expected));
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- normalize valid `xs:duration` values to invariant `TimeSpan` strings
- preserve ordinary text that only resembles a duration
- document the behavior and add focused coverage for positive and negative durations