### PR TITLE
Delete test data during database cleanup

### DIFF
--- a/publish.cmd
+++ b/publish.cmd
@@ -3,7 +3,7 @@ SET "src=%~dp0src"
 SET "props=%~dp0publish.props"
 SET "key=%NUGET_RESEED_KEY%"
 SET "outpath=%src%\Reseed\bin\publish"
-SET version=0.2.0
+SET version=0.2.1
 
 if exist %outpath%\ (
     rmdir /s /q %outpath%

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ The stages are:
 
 - **CleanupDatabase**
 
-    At this stage objects created on the `PrepareDatabase` stage are deleted if there were any. Should be executed the last and once per test fixtures.
+    At this stage data selected by the cleanup configuration is deleted, followed by any objects created on the `PrepareDatabase` stage. Should be executed the last and once per test fixtures.
 
 To generate actions you use `Reseeder.Generate` instance method by configuring generation behavior the way you like, see [Operation modes](#operation-modes) documentation section for additional details. 
 

--- a/samples/Reseed.Samples.NUnit/TestFixtureBase.cs
+++ b/samples/Reseed.Samples.NUnit/TestFixtureBase.cs
@@ -14,7 +14,7 @@ namespace Reseed.Samples.NUnit
 {
 	// One of the possible ways to use Reseeder involves creation of base type for your test fixtures.
 	// It will make sure that test database is initialized and cleaned up just once as well as
-	// insert and delete test data before/after each test run. 
+	// restore test data before each test run.
 	[TestFixture]
 	public abstract class TestFixtureBase
 	{

--- a/src/Reseed/Generation/Cleanup/CleanupActionsBuilder.cs
+++ b/src/Reseed/Generation/Cleanup/CleanupActionsBuilder.cs
@@ -20,24 +20,35 @@ namespace Reseed.Generation.Cleanup
 			if (tables == null) throw new ArgumentNullException(nameof(tables));
 			if (definition == null) throw new ArgumentNullException(nameof(definition));
 
-			return definition switch
+			switch (definition)
 			{
-				EmptyCleanupDefinition => builder,
+				case EmptyCleanupDefinition:
+					return builder;
 
-				CleanupScriptDefinition scriptDefinition => builder
-					.Add(SeedStage.Delete, DeleteScriptRenderer.Render(tables, scriptDefinition.Configuration)),
+				case CleanupScriptDefinition scriptDefinition:
+					var deleteScripts = DeleteScriptRenderer.Render(
+						tables,
+						scriptDefinition.Configuration);
 
-				CleanupProcedureDefinition procedureDefinition => builder
-					.Add(SeedStage.PrepareDb, RenderCreateProcedureScripts(
-						procedureDefinition.ProcedureName, tables, procedureDefinition.Configuration))
-					.Add(SeedStage.Delete, RenderExecuteProcedureScript(
-						ScriptNames.ExecuteDeleteSp, procedureDefinition.ProcedureName))
-					.Add(SeedStage.CleanupDb, RenderDropProcedureScript(
-						ScriptNames.DropDeleteSp, procedureDefinition.ProcedureName)),
+					return builder
+						.Add(SeedStage.Delete, deleteScripts)
+						.Add(SeedStage.CleanupDb, deleteScripts);
 
-				_ => throw new NotSupportedException(
-					$"Unknown {nameof(CleanupDefinition)} '{definition.GetType().Name}'")
-			};
+				case CleanupProcedureDefinition procedureDefinition:
+					return builder
+						.Add(SeedStage.PrepareDb, RenderCreateProcedureScripts(
+							procedureDefinition.ProcedureName, tables, procedureDefinition.Configuration))
+						.Add(SeedStage.Delete, RenderExecuteProcedureScript(
+							ScriptNames.ExecuteDeleteSp, procedureDefinition.ProcedureName))
+						.Add(SeedStage.CleanupDb, RenderExecuteProcedureScript(
+							ScriptNames.ExecuteDeleteSp, procedureDefinition.ProcedureName))
+						.Add(SeedStage.CleanupDb, RenderDropProcedureScript(
+							ScriptNames.DropDeleteSp, procedureDefinition.ProcedureName));
+
+				default:
+					throw new NotSupportedException(
+						$"Unknown {nameof(CleanupDefinition)} '{definition.GetType().Name}'");
+			}
 		}
 
 		private static IReadOnlyCollection<OrderedItem<SqlScriptAction>> RenderCreateProcedureScripts(

--- a/tests/Reseed.Tests.Integration/Core/Conventional.cs
+++ b/tests/Reseed.Tests.Integration/Core/Conventional.cs
@@ -29,7 +29,8 @@ namespace Reseed.Tests.Integration.Core
 			TestFixtureBase fixture,
 			Func<IDataProvider, SeedMode> createSeedMode,
 			Func<SqlEngine, Task> modifyData,
-			Func<SqlEngine, Task> assertDataRestored)
+			Func<SqlEngine, Task> assertDataRestored,
+			Func<SqlEngine, Task> assertDataCleaned)
 		{
 			await using var database = await CreateConventionalDatabase(fixture);
 			var reseeder = new Reseeder();
@@ -48,6 +49,7 @@ namespace Reseed.Tests.Integration.Core
 			await assertDataRestored(sqlEngine);
 
 			reseeder.Execute(database.ConnectionString, actions.CleanupDatabase);
+			await assertDataCleaned(sqlEngine);
 		}
 
 		public static async Task AssertGenerationFails(

--- a/tests/Reseed.Tests.Integration/Core/SeedModes.cs
+++ b/tests/Reseed.Tests.Integration/Core/SeedModes.cs
@@ -22,6 +22,13 @@ namespace Reseed.Tests.Integration.Core
 		private static TemporaryTablesInsertDefinition TemporaryTablesProcedureDefinition =>
 			TemporaryTablesInsertDefinition.Procedure(new ObjectName("spDeleteData"));
 
+		private static CleanupDefinition CleanupProcedureDefinition =>
+			CleanupDefinition.Procedure(
+				new ObjectName("spCleanupData"),
+				CleanupMode.Delete(),
+				CleanupTarget,
+				true);
+
 		public static readonly Func<IDataProvider, SeedMode> BasicScriptDelete =
 			dp => SeedMode.Basic(
 				BasicInsertDefinition.Script(),
@@ -56,6 +63,12 @@ namespace Reseed.Tests.Integration.Core
 			dp => SeedMode.Basic(
 				BasicProcedureDefinition,
 				CleanupDefinition.Script(CleanupMode.Truncate(), CleanupTarget, true),
+				dp);
+
+		public static readonly Func<IDataProvider, SeedMode> BasicScriptSpDelete =
+			dp => SeedMode.Basic(
+				BasicInsertDefinition.Script(),
+				CleanupProcedureDefinition,
 				dp);
 
 		public static readonly Func<IDataProvider, SeedMode> TempTablesScriptDelete =
@@ -98,6 +111,13 @@ namespace Reseed.Tests.Integration.Core
 				"temp",
 				TemporaryTablesProcedureDefinition,
 				CleanupDefinition.Script(CleanupMode.Delete(), CleanupTarget, true),
+				dp);
+
+		public static readonly Func<IDataProvider, SeedMode> TempTablesScriptSpDelete =
+			dp => SeedMode.TemporaryTables(
+				"temp",
+				TemporaryTablesInsertDefinition.Script(),
+				CleanupProcedureDefinition,
 				dp);
 
 		public static TestFixtureParameters[] Every()

--- a/tests/Reseed.Tests.Integration/SingleTableTests.cs
+++ b/tests/Reseed.Tests.Integration/SingleTableTests.cs
@@ -49,7 +49,8 @@ namespace Reseed.Tests.Integration
 				this,
 				this.createMode,
 				sql => sql.ExecuteNonQueryAsync("DELETE FROM [dbo].[User]"), 
-				async sql => Assert.That(await GetUsersCount(sql), Is.EqualTo(userCount)));
+				async sql => Assert.That(await GetUsersCount(sql), Is.EqualTo(userCount)),
+				async sql => Assert.That(await GetUsersCount(sql), Is.Zero));
 			
 			static Task<int> GetUsersCount(SqlEngine sqlEngine) =>
 				sqlEngine.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM [dbo].[User]");

--- a/tests/Reseed.Tests.Integration/SingleTableWithForeignKeyTests.cs
+++ b/tests/Reseed.Tests.Integration/SingleTableWithForeignKeyTests.cs
@@ -53,7 +53,8 @@ namespace Reseed.Tests.Integration
 				this,
 				this.createMode,
 				sql => sql.ExecuteNonQueryAsync("DELETE FROM [dbo].[User]"), 
-				async sql => Assert.That(await GetUsersCount(sql), Is.EqualTo(userCount)));
+				async sql => Assert.That(await GetUsersCount(sql), Is.EqualTo(userCount)),
+				async sql => Assert.That(await GetUsersCount(sql), Is.Zero));
 
 			static Task<int> GetUsersCount(SqlEngine sqlEngine) =>
 				sqlEngine.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM [dbo].[User]");


### PR DESCRIPTION
## Summary
- execute configured data cleanup during `CleanupDatabase`
- delete data before dropping cleanup procedures and temporary-table infrastructure
- verify cleanup leaves target tables empty across script and procedure modes
- update lifecycle documentation

Closes #36