### PR TITLE
Improve data type validation errors

### DIFF
--- a/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
+++ b/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
@@ -58,35 +58,20 @@ namespace Reseed.Schema.Providers
 							new ObjectName(gr.Key.TableName, gr.Key.SchemaName),
 							gr.Key.TableId,
 							primaryKeyColumns.Any() ? new Key(primaryKeyColumns) : null,
-							gr.Select(c =>
-								{
-									try
-									{
-										return new ColumnSchema(
-											c.ColumnOrder,
-											c.ColumnName,
-											new DataType(
-												c.Type.Name,
-												c.Type.MaxLength,
-												c.Type.NumericPrecision ?? c.Type.DateTimePrecision,
-												c.Type.NumericScale),
-											c.PrimaryKeyColumnOrder != null,
-											c.IsIdentityColumn,
-											c.IsIdentityColumn ? c.IdentitySeed.Value : null,
-											c.IsIdentityColumn ? c.IdentityIncrement.Value : null,
-											c.IsComputedColumn,
-											c.IsNullableColumn,
-											c.ColumnDefaultValue);
-									}
-									catch (Exception ex)
-									{
-										var maxLength = c.Type.MaxLength?.ToString() ?? "null";
-										throw new Exception(
-											$"Unsupported schema for column '{c.ColumnName}': " +
-											$"data type '{c.Type.Name}', max length {maxLength}",
-											ex);
-									}
-								})
+							gr.Select(c => CreateColumnSchema(
+									c.ColumnOrder,
+									c.ColumnName,
+									c.Type.Name,
+									c.Type.MaxLength,
+									c.Type.NumericPrecision ?? c.Type.DateTimePrecision,
+									c.Type.NumericScale,
+									c.PrimaryKeyColumnOrder != null,
+									c.IsIdentityColumn,
+									c.IsIdentityColumn ? c.IdentitySeed.Value : null,
+									c.IsIdentityColumn ? c.IdentityIncrement.Value : null,
+									c.IsComputedColumn,
+									c.IsNullableColumn,
+									c.ColumnDefaultValue))
 								.ToArray());
 					}
 					catch (Exception ex)
@@ -96,6 +81,45 @@ namespace Reseed.Schema.Providers
 					}
 				})
 				.ToArray();
+		}
+
+		private static ColumnSchema CreateColumnSchema(
+			int columnOrder,
+			string columnName,
+			string typeName,
+			int? maxLength,
+			int? precision,
+			int? scale,
+			bool isPrimaryKey,
+			bool isIdentity,
+			decimal? identitySeed,
+			decimal? identityIncrement,
+			bool isComputed,
+			bool isNullable,
+			string defaultValue)
+		{
+			try
+			{
+				return new ColumnSchema(
+					columnOrder,
+					columnName,
+					new DataType(typeName, maxLength, precision, scale),
+					isPrimaryKey,
+					isIdentity,
+					identitySeed,
+					identityIncrement,
+					isComputed,
+					isNullable,
+					defaultValue);
+			}
+			catch (Exception ex)
+			{
+				var maxLengthText = maxLength?.ToString() ?? "null";
+				throw new Exception(
+					$"Unsupported schema for column '{columnName}': " +
+					$"data type '{typeName}', max length {maxLengthText}",
+					ex);
+			}
 		}
 
 		internal static IReadOnlyCollection<Relation<TableData>> LoadForeignKeys(

--- a/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
+++ b/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
@@ -58,21 +58,35 @@ namespace Reseed.Schema.Providers
 							new ObjectName(gr.Key.TableName, gr.Key.SchemaName),
 							gr.Key.TableId,
 							primaryKeyColumns.Any() ? new Key(primaryKeyColumns) : null,
-							gr.Select(c => new ColumnSchema(
-									c.ColumnOrder,
-									c.ColumnName,
-									new DataType(
-										c.Type.Name,
-										c.Type.MaxLength,
-										c.Type.NumericPrecision ?? c.Type.DateTimePrecision,
-										c.Type.NumericScale),
-									c.PrimaryKeyColumnOrder != null,
-									c.IsIdentityColumn,
-									c.IsIdentityColumn ? c.IdentitySeed.Value : null,
-									c.IsIdentityColumn ? c.IdentityIncrement.Value : null,
-									c.IsComputedColumn,
-									c.IsNullableColumn,
-									c.ColumnDefaultValue))
+							gr.Select(c =>
+								{
+									try
+									{
+										return new ColumnSchema(
+											c.ColumnOrder,
+											c.ColumnName,
+											new DataType(
+												c.Type.Name,
+												c.Type.MaxLength,
+												c.Type.NumericPrecision ?? c.Type.DateTimePrecision,
+												c.Type.NumericScale),
+											c.PrimaryKeyColumnOrder != null,
+											c.IsIdentityColumn,
+											c.IsIdentityColumn ? c.IdentitySeed.Value : null,
+											c.IsIdentityColumn ? c.IdentityIncrement.Value : null,
+											c.IsComputedColumn,
+											c.IsNullableColumn,
+											c.ColumnDefaultValue);
+									}
+									catch (Exception ex)
+									{
+										var maxLength = c.Type.MaxLength?.ToString() ?? "null";
+										throw new Exception(
+											$"Unsupported schema for column '{c.ColumnName}': " +
+											$"data type '{c.Type.Name}', max length {maxLength}",
+											ex);
+									}
+								})
 								.ToArray());
 					}
 					catch (Exception ex)


### PR DESCRIPTION
## Summary
- add column-level context when SQL Server schema construction fails
- include the column name, SQL data type, and reported maximum length
- preserve the existing table-level context and original exception chain

Related discussion: https://github.com/uladz-zubrycki/Reseed/discussions/37