### PR TITLE
Handle indexed views in cleanup modes

### DIFF
--- a/publish.cmd
+++ b/publish.cmd
@@ -3,7 +3,7 @@ SET "src=%~dp0src"
 SET "props=%~dp0publish.props"
 SET "key=%NUGET_RESEED_KEY%"
 SET "outpath=%src%\Reseed\bin\publish"
-SET version=0.2.1
+SET version=0.2.2
 
 if exist %outpath%\ (
     rmdir /s /q %outpath%

--- a/readme.md
+++ b/readme.md
@@ -250,7 +250,7 @@ Also you should specify how each table will be cleaned. There are a few cleanup 
     CleanupMode.PreferTruncate(ObjectName[], ConstraintResolutionBehavior); 
     ``` 
 
-    Pretty much as the previous one, but if Reseed finds that table has no relations, then `TRUNCATE TABLE` statement is used, which should be a lot faster; `DELETE FROM` is used otherwise. It's possible to explicitly specify tables to use `DELETE FROM` for and to choose constraints resolution behavior. 
+    Pretty much as the previous one, but if Reseed finds that table has no incoming foreign keys or indexed view dependencies, then `TRUNCATE TABLE` statement is used, which should be a lot faster; `DELETE FROM` is used otherwise. It's possible to explicitly specify tables to use `DELETE FROM` for and to choose constraints resolution behavior.
     
 3. **Truncate**
 

--- a/src/Reseed/Configuration/Cleanup/CleanupMode.cs
+++ b/src/Reseed/Configuration/Cleanup/CleanupMode.cs
@@ -29,7 +29,7 @@ namespace Reseed.Configuration.Cleanup
 			new TruncateCleanupMode(constraintBehavior, useDeleteForTables ?? Array.Empty<ObjectName>());
 
 		/// <summary>
-		/// Uses TRUNCATE to clean data from tables, which aren't referenced by any foreign key.
+		/// Uses TRUNCATE to clean data from tables, which aren't referenced by any foreign key or indexed view.
 		/// Cleans data with use of DELETE FROM otherwise.
 		/// </summary>
 		public static CleanupMode PreferTruncate(

--- a/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
+++ b/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
@@ -90,6 +90,7 @@ namespace Reseed.Generation.Cleanup
 			var (toDelete, toTruncate) =
 				defaultClean.PartitionBy(o =>
 					cleanupMode.ShouldUseDelete(o.Value.Name) ||
+					o.Value.IsReferencedByIndexedView ||
 					getAllIncomingRelations(o.Value).Any());
 
 			var persistentTables = rest.Concat(customClean).ToArray();

--- a/src/Reseed/Generation/TemporaryTables/TemporaryTablesActionGenerator.cs
+++ b/src/Reseed/Generation/TemporaryTables/TemporaryTablesActionGenerator.cs
@@ -147,7 +147,8 @@ namespace Reseed.Generation.TemporaryTables
 							CreateTempTableName(tempSchemaName, t.Name),
 							t.Columns,
 							t.PrimaryKey,
-							rs));
+							rs,
+							false));
 
 		private static OrderedItem<ITableContainer>[] MapContainers(
 			string tempSchemaName,

--- a/src/Reseed/Schema/Providers/MsSqlSchemaProvider.cs
+++ b/src/Reseed/Schema/Providers/MsSqlSchemaProvider.cs
@@ -35,6 +35,7 @@ namespace Reseed.Schema.Providers
 			new(table.Name,
 				table.Columns,
 				table.PrimaryKey,
-				references);
+				references,
+				table.IsReferencedByIndexedView);
 	}
 }

--- a/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
+++ b/src/Reseed/Schema/Providers/MsSqlSchemaReader.cs
@@ -31,6 +31,7 @@ namespace Reseed.Schema.Providers
 						IdentitySeed = r.GetSqlDecimal(cs["IdentitySeed"]),
 						IdentityIncrement = r.GetSqlDecimal(cs["IdentityIncrement"]),
 						IsComputedColumn = r.GetInt32(cs["IsComputedColumn"]) == 1,
+						IsReferencedByIndexedView = r.GetInt32(cs["IsReferencedByIndexedView"]) == 1,
 						PrimaryKeyColumnOrder = primaryKeyOrder == -1 ? (int?) null : primaryKeyOrder,
 						Type = new
 						{
@@ -73,7 +74,8 @@ namespace Reseed.Schema.Providers
 									c.IsComputedColumn,
 									c.IsNullableColumn,
 									c.ColumnDefaultValue))
-								.ToArray());
+								.ToArray(),
+							gr.First().IsReferencedByIndexedView);
 					}
 					catch (Exception ex)
 					{
@@ -166,6 +168,13 @@ namespace Reseed.Schema.Providers
 			|	IDENT_SEED (c.[table_schema] + '.' + c.[table_name]) as IdentitySeed,  
 			|	IDENT_INCR (c.[table_schema] + '.' + c.[table_name]) as IdentityIncrement,  
 			|	columnproperty(t.[object_id], c.[column_name],'IsComputed') as IsComputedColumn,
+			|	CASE WHEN EXISTS (
+			|		SELECT 1
+			|		FROM [sys].[sql_expression_dependencies] AS d
+			|		JOIN [sys].[views] AS v ON d.[referencing_id] = v.[object_id]
+			|		JOIN [sys].[indexes] AS vi ON v.[object_id] = vi.[object_id]
+			|		WHERE d.[referenced_id] = t.[object_id] AND vi.[index_id] = 1
+			|	) THEN 1 ELSE 0 END AS IsReferencedByIndexedView,
 			|	COALESCE((
 			|		SELECT ic.[key_ordinal]
 			|		FROM [sys].[indexes] AS i 

--- a/src/Reseed/Schema/TableData.cs
+++ b/src/Reseed/Schema/TableData.cs
@@ -9,12 +9,14 @@ namespace Reseed.Schema
 		public readonly int ObjectId;
 		public readonly Key PrimaryKey;
 		public readonly ColumnSchema[] Columns;
+		public readonly bool IsReferencedByIndexedView;
 
 		public TableData(
 			[NotNull] ObjectName name, 
 			int objectId,
 			[CanBeNull] Key primaryKey,
-			[NotNull] ColumnSchema[] columns)
+			[NotNull] ColumnSchema[] columns,
+			bool isReferencedByIndexedView)
 		{
 			if (columns == null) throw new ArgumentNullException(nameof(columns));
 			if (columns.Length == 0)
@@ -24,6 +26,7 @@ namespace Reseed.Schema
 			this.ObjectId = objectId;
 			this.PrimaryKey = primaryKey;
 			this.Columns = columns;
+			this.IsReferencedByIndexedView = isReferencedByIndexedView;
 		}
 
 		public override string ToString() => this.Name.ToString();

--- a/src/Reseed/Schema/TableSchema.cs
+++ b/src/Reseed/Schema/TableSchema.cs
@@ -14,12 +14,14 @@ namespace Reseed.Schema
 		public readonly ObjectName Name;
 		public readonly Key PrimaryKey;
 		public readonly IReadOnlyCollection<ColumnSchema> Columns;
+		public readonly bool IsReferencedByIndexedView;
 		public IReadOnlyCollection<Reference<TableSchema>> References => this.references;
 		
 		private TableSchema(
 			[NotNull] ObjectName name,
 			[NotNull] IReadOnlyCollection<ColumnSchema> columns,
-			[CanBeNull] Key primaryKey)
+			[CanBeNull] Key primaryKey,
+			bool isReferencedByIndexedView)
 		{
 			if (columns == null) throw new ArgumentNullException(nameof(columns));
 			if (columns.Count == 0)
@@ -29,14 +31,16 @@ namespace Reseed.Schema
 			this.Name = name ?? throw new ArgumentNullException(nameof(name));
 			this.Columns = columns;
 			this.PrimaryKey = primaryKey;
+			this.IsReferencedByIndexedView = isReferencedByIndexedView;
 		}
 
 		public TableSchema(
 			[NotNull] ObjectName name,
 			[NotNull] IReadOnlyCollection<ColumnSchema> columns,
 			[NotNull] Key primaryKey,
-			[NotNull] IReadOnlyCollection<Reference<TableSchema>> references)
-			: this(name, columns, primaryKey)
+			[NotNull] IReadOnlyCollection<Reference<TableSchema>> references,
+			bool isReferencedByIndexedView)
+			: this(name, columns, primaryKey, isReferencedByIndexedView)
 		{
 			this.references = new List<Reference<TableSchema>>(references);
 		}
@@ -56,7 +60,8 @@ namespace Reseed.Schema
 				this.Name,
 				this.Columns,
 				this.PrimaryKey,
-				items);
+				items,
+				this.IsReferencedByIndexedView);
 		}
 
 		private static void VerifyPrimaryKeyColumns(IReadOnlyCollection<ColumnSchema> columns, Key primaryKey)

--- a/tests/Reseed.Tests.Integration/CleanupTests.cs
+++ b/tests/Reseed.Tests.Integration/CleanupTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Reseed.Configuration;
+using Reseed.Configuration.Cleanup;
+using Reseed.Generation;
+using Reseed.Tests.Integration.Core;
+
+namespace Reseed.Tests.Integration
+{
+	[Parallelizable(ParallelScope.Fixtures)]
+	public sealed class CleanupTests : TestFixtureBase
+	{
+		[Test]
+		public async Task ShouldPreferDeleteForTableReferencedByIndexedView()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var sql = new SqlEngine(database.ConnectionString);
+
+			var reseeder = new Reseeder();
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.PreferTruncate(),
+					CleanupTarget.Excluding())));
+
+			var cleanupScript = string.Join(
+				System.Environment.NewLine,
+				actions.RestoreData
+					.Select(a => a.Value)
+					.OfType<SqlScriptAction>()
+					.Select(a => a.Text));
+
+			Assert.That(cleanupScript, Does.Contain("DELETE FROM [dbo].[User];"));
+			Assert.That(cleanupScript, Does.Not.Contain("TRUNCATE TABLE [dbo].[User];"));
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+
+			Assert.That(
+				await sql.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM [dbo].[User]"),
+				Is.Zero);
+		}
+	}
+}

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/01_ShouldPreferDeleteForTableReferencedByIndexedView.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/01_ShouldPreferDeleteForTableReferencedByIndexedView.sql
@@ -1,0 +1,22 @@
+﻿CREATE TABLE [User] (
+	Id int NOT NULL IDENTITY(1, 1) PRIMARY KEY,
+	FirstName nvarchar(100) NOT NULL,
+	LastName nvarchar(100) NOT NULL,
+	Age int NULL
+);
+
+INSERT INTO [User] (FirstName, LastName, Age)
+VALUES (N'John', N'Doe', 30);
+
+GO
+
+CREATE VIEW [dbo].[viUser]
+WITH SCHEMABINDING
+AS
+	SELECT [Id], [FirstName], [LastName]
+	FROM [dbo].[User];
+
+GO
+
+CREATE UNIQUE CLUSTERED INDEX [IX_viUser_Id]
+	ON [dbo].[viUser] ([Id]);

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -22,6 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Data\CleanupTests\01_ShouldPreferDeleteForTableReferencedByIndexedView.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Data\SingleTableTests\04_ShouldInsert_RowVersionMissing.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- detect tables referenced by indexed views while loading SQL Server schema metadata
- make `PreferTruncate` use `DELETE FROM` for those tables
- reject explicit `Truncate` generation with a clear diagnostic unless affected tables are listed in `useDeleteForTables`
- preserve temporary-table metadata and document the cleanup behavior
- bump and publish package version 0.2.2

## Testing
- `dotnet build .\Reseed.sln --no-restore --verbosity minimal`
- `dotnet test .\tests\Reseed.Tests.Integration\Reseed.Tests.Integration.csproj --no-restore --configuration Debug --filter FullyQualifiedName~CleanupTests --verbosity minimal`