### PR TITLE
Reject truncating indexed-view tables

### DIFF
--- a/publish.cmd
+++ b/publish.cmd
@@ -3,7 +3,7 @@ SET "src=%~dp0src"
 SET "props=%~dp0publish.props"
 SET "key=%NUGET_RESEED_KEY%"
 SET "outpath=%src%\Reseed\bin\publish"
-SET version=0.2.2
+SET version=0.2.3
 
 if exist %outpath%\ (
     rmdir /s /q %outpath%

--- a/src/Reseed/Configuration/Cleanup/CleanupMode.cs
+++ b/src/Reseed/Configuration/Cleanup/CleanupMode.cs
@@ -20,8 +20,7 @@ namespace Reseed.Configuration.Cleanup
 		/// Uses TRUNCATE to clean data from provided tables.
 		/// In order to do so it drops foreign keys referencing tables and recreates them afterwards.
 		/// Note that truncate is not possible if table is referenced by a view with index.
-		/// This case isn't handled automatically, therefore script will just fail if such table exists.
-		/// To fix this either drop required views/indexes manually or choose delete mode for these tables.
+		/// Generation fails for such tables unless they are configured to use delete.
 		/// </summary>
 		public static CleanupMode Truncate(
 			ObjectName[] useDeleteForTables = null,

--- a/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
+++ b/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
@@ -138,6 +138,18 @@ namespace Reseed.Generation.Cleanup
 				defaultClean.PartitionBy(o => cleanupMode.ShouldUseDelete(o.Value.Name));
 
 			var tablesToTruncate = toTruncate.Unordered().ToArray();
+			var tablesReferencedByIndexedViews = tablesToTruncate
+				.Where(t => t.IsReferencedByIndexedView)
+				.Select(t => t.Name)
+				.ToArray();
+			if (tablesReferencedByIndexedViews.Length > 0)
+			{
+				throw new InvalidOperationException(
+					$"Cleanup mode '{nameof(CleanupMode.Truncate)}' can't truncate tables referenced by indexed views: " +
+					$"{string.Join(", ", tablesReferencedByIndexedViews.Select(t => t.ToString()))}. " +
+					"Add these tables to the useDeleteForTables argument or use CleanupMode.PreferTruncate().");
+			}
+
 			var foreignKeys =
 				tablesToTruncate.SelectMany(getAllIncomingRelations).Distinct().ToArray();
 

--- a/tests/Reseed.Tests.Integration/CleanupTests.cs
+++ b/tests/Reseed.Tests.Integration/CleanupTests.cs
@@ -1,9 +1,11 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Reseed.Configuration;
 using Reseed.Configuration.Cleanup;
 using Reseed.Generation;
+using Reseed.Schema;
 using Reseed.Tests.Integration.Core;
 
 namespace Reseed.Tests.Integration
@@ -24,12 +26,7 @@ namespace Reseed.Tests.Integration
 					CleanupMode.PreferTruncate(),
 					CleanupTarget.Excluding())));
 
-			var cleanupScript = string.Join(
-				System.Environment.NewLine,
-				actions.RestoreData
-					.Select(a => a.Value)
-					.OfType<SqlScriptAction>()
-					.Select(a => a.Text));
+			var cleanupScript = GetCleanupScript(actions);
 
 			Assert.That(cleanupScript, Does.Contain("DELETE FROM [dbo].[User];"));
 			Assert.That(cleanupScript, Does.Not.Contain("TRUNCATE TABLE [dbo].[User];"));
@@ -40,5 +37,47 @@ namespace Reseed.Tests.Integration
 				await sql.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM [dbo].[User]"),
 				Is.Zero);
 		}
+
+		[Test]
+		public async Task ShouldRejectTruncateForTableReferencedByIndexedView()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var reseeder = new Reseeder();
+
+			var exception = Assert.Throws<InvalidOperationException>(() => reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.Truncate(),
+					CleanupTarget.Excluding()))));
+
+			Assert.That(exception.Message, Is.EqualTo(
+				"Cleanup mode 'Truncate' can't truncate tables referenced by indexed views: dbo.User. " +
+				"Add these tables to the useDeleteForTables argument or use CleanupMode.PreferTruncate()."));
+		}
+
+		[Test]
+		public async Task ShouldUseDeleteIfExplicitlyRequested()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var reseeder = new Reseeder();
+
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.Truncate(new[] { new ObjectName("User") }),
+					CleanupTarget.Excluding())));
+
+			Assert.That(
+				GetCleanupScript(actions),
+				Does.Contain("DELETE FROM [dbo].[User];"));
+		}
+
+		private static string GetCleanupScript(SeedActions actions) =>
+			string.Join(
+				System.Environment.NewLine,
+				actions.RestoreData
+					.Select(a => a.Value)
+					.OfType<SqlScriptAction>()
+					.Select(a => a.Text));
 	}
 }

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/02_ShouldRejectTruncateForTableReferencedByIndexedView.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/02_ShouldRejectTruncateForTableReferencedByIndexedView.sql
@@ -1,0 +1,22 @@
+CREATE TABLE [User] (
+	Id int NOT NULL IDENTITY(1, 1) PRIMARY KEY,
+	FirstName nvarchar(100) NOT NULL,
+	LastName nvarchar(100) NOT NULL,
+	Age int NULL
+);
+
+INSERT INTO [User] (FirstName, LastName, Age)
+VALUES (N'John', N'Doe', 30);
+
+GO
+
+CREATE VIEW [dbo].[viUser]
+WITH SCHEMABINDING
+AS
+	SELECT [Id], [FirstName], [LastName]
+	FROM [dbo].[User];
+
+GO
+
+CREATE UNIQUE CLUSTERED INDEX [IX_viUser_Id]
+	ON [dbo].[viUser] ([Id]);

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/03_ShouldUseDeleteIfExplicitlyRequested.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/03_ShouldUseDeleteIfExplicitlyRequested.sql
@@ -1,0 +1,22 @@
+CREATE TABLE [User] (
+	Id int NOT NULL IDENTITY(1, 1) PRIMARY KEY,
+	FirstName nvarchar(100) NOT NULL,
+	LastName nvarchar(100) NOT NULL,
+	Age int NULL
+);
+
+INSERT INTO [User] (FirstName, LastName, Age)
+VALUES (N'John', N'Doe', 30);
+
+GO
+
+CREATE VIEW [dbo].[viUser]
+WITH SCHEMABINDING
+AS
+	SELECT [Id], [FirstName], [LastName]
+	FROM [dbo].[User];
+
+GO
+
+CREATE UNIQUE CLUSTERED INDEX [IX_viUser_Id]
+	ON [dbo].[viUser] ([Id]);

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -25,6 +25,12 @@
     <None Update="Data\CleanupTests\01_ShouldPreferDeleteForTableReferencedByIndexedView.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Data\CleanupTests\02_ShouldRejectTruncateForTableReferencedByIndexedView.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\CleanupTests\03_ShouldUseDeleteIfExplicitlyRequested.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Data\SingleTableTests\04_ShouldInsert_RowVersionMissing.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- reject `CleanupMode.Truncate` at generation time when a selected table is referenced by an indexed view
- allow explicit per-table delete overrides through `useDeleteForTables`
- add focused integration coverage and update cleanup-mode documentation

## Testing
- `dotnet test tests\Reseed.Tests.Integration\Reseed.Tests.Integration.csproj --filter "FullyQualifiedName~CleanupTests" --no-restore`