### PR TITLE
Add DropConstraints cleanup behavior

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ See the [Examples](https://github.com/v-zubritsky/Reseed#examples) section below
 
 * It's possible to generate scripts for either data seeding or cleanup only or both;
 * Reseed is able to order tables graph (tables are nodes, foreign keys are edges), so that foreign key constraints are respected in the insertion and deletion scripts;
-* Alternatively Reseed could simply disable foreign key constraints to deal with such data dependecies;
+* Alternatively Reseed can disable or drop and recreate foreign key constraints to deal with such data dependencies;
 * It detects cyclic foreign key dependencies on both tables and rows levels, so that loops don't break anything. More on this in [Constraints resolution](#constraints-resolution);
 * You could specify [Custom cleanup scripts](#custom-cleanup-scripts) for specific tables to ignore rows during data cleanup;
 * Data schema is read from the database and there is no need to describe it manually (e.g NDbUnit requires XSD files);
@@ -250,7 +250,7 @@ Also you should specify how each table will be cleaned. There are a few cleanup 
     CleanupMode.PreferTruncate(ObjectName[], ConstraintResolutionBehavior); 
     ``` 
 
-    Pretty much as the previous one, but if Reseed finds that table has no incoming foreign keys or indexed view dependencies, then `TRUNCATE TABLE` statement is used, which should be a lot faster; `DELETE FROM` is used otherwise. It's possible to explicitly specify tables to use `DELETE FROM` for and to choose constraints resolution behavior.
+    Pretty much as the previous one, but Reseed uses the faster `TRUNCATE TABLE` statement where possible. By default, `DELETE FROM` is used for tables with incoming foreign keys or indexed view dependencies. With `ConstraintResolutionBehavior.DropConstraints`, incoming foreign keys are dropped and recreated so those tables can also be truncated; indexed view dependencies still require `DELETE FROM`. It's possible to explicitly specify tables to use `DELETE FROM` for.
     
 3. **Truncate**
 
@@ -258,7 +258,7 @@ Also you should specify how each table will be cleaned. There are a few cleanup 
      CleanupMode.Truncate(ObjectName[], ConstraintResolutionBehavior);
     ```
 
-    Reseed uses `TRUNCATE TABLE` for every table in spite of the foreign keys presence. It drops foreign keys and recreates them as it's not possible to use `TRUNCATE TABLE` statement otherwise. Similarly to the `PreferTruncate` mode you might force usage `DELETE FROM` for some of the tables and choose constraints resolution behavior for those. 
+    Reseed uses `TRUNCATE TABLE` for every table regardless of foreign keys. It drops foreign keys and recreates them because `TRUNCATE TABLE` cannot otherwise be used. Similarly to the `PreferTruncate` mode, you can force `DELETE FROM` for specific tables and choose the constraint resolution behavior for those tables.
     
 4. **Switch tables** (Work in progress)
 
@@ -427,7 +427,17 @@ DataProviders.Inline(builder =>
 ```
 
 # Constraints resolution
-TBD
+
+Cleanup modes accept a `ConstraintResolutionBehavior`:
+
+- `OrderTables` orders `DELETE FROM` statements by foreign key dependencies and temporarily disables constraints only for mutually dependent tables. This is the default.
+- `DisableConstraints` temporarily disables all applicable foreign keys around `DELETE FROM` statements.
+- `DropConstraints` drops applicable foreign keys before cleanup and recreates them afterward. In `PreferTruncate` mode, this also permits FK-related tables to use `TRUNCATE TABLE`; tables referenced by indexed views still use `DELETE FROM`.
+
+```csharp
+CleanupMode.PreferTruncate(
+    constraintBehavior: ConstraintResolutionBehavior.DropConstraints);
+```
 
 # Data Extension
 

--- a/src/Reseed/Configuration/Cleanup/CleanupMode.cs
+++ b/src/Reseed/Configuration/Cleanup/CleanupMode.cs
@@ -28,8 +28,9 @@ namespace Reseed.Configuration.Cleanup
 			new TruncateCleanupMode(constraintBehavior, useDeleteForTables ?? Array.Empty<ObjectName>());
 
 		/// <summary>
-		/// Uses TRUNCATE to clean data from tables, which aren't referenced by any foreign key or indexed view.
-		/// Cleans data with use of DELETE FROM otherwise.
+		/// Uses TRUNCATE to clean data from tables which aren't referenced by an indexed view.
+		/// Tables referenced by foreign keys are truncated when constraints are dropped and recreated;
+		/// otherwise they are cleaned with use of DELETE FROM.
 		/// </summary>
 		public static CleanupMode PreferTruncate(
 			ObjectName[] useDeleteForTables = null,

--- a/src/Reseed/Configuration/Cleanup/CleanupMode.cs
+++ b/src/Reseed/Configuration/Cleanup/CleanupMode.cs
@@ -28,9 +28,8 @@ namespace Reseed.Configuration.Cleanup
 			new TruncateCleanupMode(constraintBehavior, useDeleteForTables ?? Array.Empty<ObjectName>());
 
 		/// <summary>
-		/// Uses TRUNCATE to clean data from tables which aren't referenced by an indexed view.
-		/// Tables referenced by foreign keys are truncated when constraints are dropped and recreated;
-		/// otherwise they are cleaned with use of DELETE FROM.
+		/// Uses TRUNCATE when possible and falls back to DELETE.
+		/// <see cref="ConstraintResolutionBehavior"/> determines how foreign key constraints are handled.
 		/// </summary>
 		public static CleanupMode PreferTruncate(
 			ObjectName[] useDeleteForTables = null,

--- a/src/Reseed/Configuration/Cleanup/ConstraintResolutionBehavior.cs
+++ b/src/Reseed/Configuration/Cleanup/ConstraintResolutionBehavior.cs
@@ -12,8 +12,13 @@ namespace Reseed.Configuration.Cleanup
 		OrderTables,
 
 		/// <summary>
-		/// Temporary disables all foreign key constraints to be able to execute DELETE FROM.
+		/// Temporarily disables all foreign key constraints to be able to execute DELETE FROM.
 		/// </summary>
-		DisableConstraints
+		DisableConstraints,
+
+		/// <summary>
+		/// Drops all foreign key constraints before cleanup and recreates them afterwards.
+		/// </summary>
+		DropConstraints
 	}
 }

--- a/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
+++ b/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
@@ -57,9 +57,10 @@ namespace Reseed.Generation.Cleanup
 				{
 					ConstraintResolutionBehavior.OrderTables =>
 						BuildIncomingRelationsGetter(persistentTables),
-					ConstraintResolutionBehavior.DisableConstraints or
-						ConstraintResolutionBehavior.DropConstraints =>
+					ConstraintResolutionBehavior.DisableConstraints =>
 						BuildIncomingRelationsGetter(tables),
+					ConstraintResolutionBehavior.DropConstraints =>
+						GetNoIncomingRelations,
 					_ => throw new NotSupportedException(
 						$"Unknown {nameof(ConstraintResolutionBehavior)} value " +
 						$"'{cleanupMode.ConstraintBehavior}'")
@@ -67,18 +68,13 @@ namespace Reseed.Generation.Cleanup
 			var getCustomIncomingRelations = BuildIncomingRelationsGetter(persistentTables);
 			var shouldDropConstraints =
 				cleanupMode.ConstraintBehavior == ConstraintResolutionBehavior.DropConstraints;
-			var foreignKeys = shouldDropConstraints
-				? defaultClean
-					.SelectMany(o => getDefaultDeleteIncomingRelations(o.Value))
-					.Concat(customClean.SelectMany(o => getCustomIncomingRelations(o.Value)))
-					.ToArray()
-				: Array.Empty<Relation<TableSchema>>();
+			var foreignKeysToDrop = GetForeignKeysToDrop();
 
 			var cleanupScripts = new List<SqlScriptAction>(4)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Drop Foreign Keys",
-						RenderDropForeignKeys(foreignKeys, false)),
-					foreignKeys.Length > 0)
+						RenderDropForeignKeys(foreignKeysToDrop, false)),
+					foreignKeysToDrop.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Delete from tables",
 						string.Join(Environment.NewLine + Environment.NewLine,
@@ -99,14 +95,29 @@ namespace Reseed.Generation.Cleanup
 					customClean.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Create Foreign Keys",
-						RenderCreateForeignKeys(foreignKeys)),
-					foreignKeys.Length > 0)
+						RenderCreateForeignKeys(foreignKeysToDrop)),
+					foreignKeysToDrop.Length > 0)
 				.WithNaturalOrder()
 				.ToArray();
 
 			return WrapDroppedConstraintCleanupInTransaction(
 				cleanupScripts,
-				shouldDropConstraints && foreignKeys.Length > 0);
+				shouldDropConstraints && foreignKeysToDrop.Length > 0);
+
+			Relation<TableSchema>[] GetForeignKeysToDrop() =>
+				cleanupMode.ConstraintBehavior switch
+				{
+					ConstraintResolutionBehavior.DropConstraints =>
+						tables
+							.SelectMany(t => t.Value.GetRelations())
+							.ToArray(),
+					ConstraintResolutionBehavior.OrderTables or
+						ConstraintResolutionBehavior.DisableConstraints =>
+						Array.Empty<Relation<TableSchema>>(),
+					_ => throw new NotSupportedException(
+						$"Unknown {nameof(ConstraintResolutionBehavior)} value " +
+						$"'{cleanupMode.ConstraintBehavior}'")
+				};
 		}
 
 		private static IReadOnlyCollection<OrderedItem<SqlScriptAction>> RenderPreferTruncateScripts(

--- a/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
+++ b/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
@@ -52,16 +52,24 @@ namespace Reseed.Generation.Cleanup
 				toClean.PartitionBy(o => !cleanupTarget.GetCustomScript(o.Value.Name, out _));
 
 			var persistentTables = rest.Concat(customClean).ToArray();
-			var getDefaultIncomingRelations = ChooseIncomingRelationsGetter(
-				tables,
-				persistentTables,
-				cleanupMode.ConstraintBehavior);
+			var getDefaultDeleteIncomingRelations =
+				cleanupMode.ConstraintBehavior switch
+				{
+					ConstraintResolutionBehavior.OrderTables =>
+						BuildIncomingRelationsGetter(persistentTables),
+					ConstraintResolutionBehavior.DisableConstraints or
+						ConstraintResolutionBehavior.DropConstraints =>
+						BuildIncomingRelationsGetter(tables),
+					_ => throw new NotSupportedException(
+						$"Unknown {nameof(ConstraintResolutionBehavior)} value " +
+						$"'{cleanupMode.ConstraintBehavior}'")
+				};
 			var getCustomIncomingRelations = BuildIncomingRelationsGetter(persistentTables);
 			var shouldDropConstraints =
 				cleanupMode.ConstraintBehavior == ConstraintResolutionBehavior.DropConstraints;
 			var foreignKeys = shouldDropConstraints
 				? defaultClean
-					.SelectMany(o => getDefaultIncomingRelations(o.Value))
+					.SelectMany(o => getDefaultDeleteIncomingRelations(o.Value))
 					.Concat(customClean.SelectMany(o => getCustomIncomingRelations(o.Value)))
 					.ToArray()
 				: Array.Empty<Relation<TableSchema>>();
@@ -78,7 +86,7 @@ namespace Reseed.Generation.Cleanup
 								FilterGraph(orderedTables, defaultClean),
 								shouldDropConstraints
 									? GetNoIncomingRelations
-									: getDefaultIncomingRelations,
+									: getDefaultDeleteIncomingRelations,
 								cleanupMode.ConstraintBehavior))),
 					defaultClean.Length > 0)
 				.AddScriptWhen(() => new SqlScriptAction("Custom cleanup scripts",
@@ -124,10 +132,18 @@ namespace Reseed.Generation.Cleanup
 					(!shouldDropConstraints && getAllIncomingRelations(o.Value).Any()));
 
 			var persistentTables = rest.Concat(customClean).ToArray();
-			var getDeleteIncomingRelations = ChooseIncomingRelationsGetter(
-				tables,
-				persistentTables,
-				cleanupMode.ConstraintBehavior);
+			var getDeleteIncomingRelations =
+				cleanupMode.ConstraintBehavior switch
+				{
+					ConstraintResolutionBehavior.OrderTables =>
+						BuildIncomingRelationsGetter(persistentTables),
+					ConstraintResolutionBehavior.DisableConstraints or
+						ConstraintResolutionBehavior.DropConstraints =>
+						BuildIncomingRelationsGetter(tables),
+					_ => throw new NotSupportedException(
+						$"Unknown {nameof(ConstraintResolutionBehavior)} value " +
+						$"'{cleanupMode.ConstraintBehavior}'")
+				};
 			var getCustomIncomingRelations = BuildIncomingRelationsGetter(persistentTables);
 			var foreignKeys = shouldDropConstraints
 				? toTruncate
@@ -208,10 +224,18 @@ namespace Reseed.Generation.Cleanup
 			}
 
 			var persistentTables = rest.Concat(customClean).ToArray();
-			var getDeleteIncomingRelations = ChooseIncomingRelationsGetter(
-				tables,
-				persistentTables,
-				cleanupMode.ConstraintBehavior);
+			var getDeleteIncomingRelations =
+				cleanupMode.ConstraintBehavior switch
+				{
+					ConstraintResolutionBehavior.OrderTables =>
+						BuildIncomingRelationsGetter(persistentTables),
+					ConstraintResolutionBehavior.DisableConstraints or
+						ConstraintResolutionBehavior.DropConstraints =>
+						BuildIncomingRelationsGetter(tables),
+					_ => throw new NotSupportedException(
+						$"Unknown {nameof(ConstraintResolutionBehavior)} value " +
+						$"'{cleanupMode.ConstraintBehavior}'")
+				};
 			var getCustomIncomingRelations = BuildIncomingRelationsGetter(persistentTables);
 			var shouldDropConstraints =
 				cleanupMode.ConstraintBehavior == ConstraintResolutionBehavior.DropConstraints;
@@ -262,19 +286,6 @@ namespace Reseed.Generation.Cleanup
 				cleanupScripts,
 				shouldDropConstraints && foreignKeys.Length > 0);
 		}
-
-		private static Func<TableSchema, Relation<TableSchema>[]> ChooseIncomingRelationsGetter(
-			IEnumerable<OrderedItem<TableSchema>> allTables,
-			IEnumerable<OrderedItem<TableSchema>> persistentTables,
-			ConstraintResolutionBehavior resolutionKind) =>
-			resolutionKind switch
-			{
-				ConstraintResolutionBehavior.OrderTables => BuildIncomingRelationsGetter(persistentTables),
-				ConstraintResolutionBehavior.DisableConstraints => BuildIncomingRelationsGetter(allTables),
-				ConstraintResolutionBehavior.DropConstraints => BuildIncomingRelationsGetter(allTables),
-				_ => throw new NotSupportedException(
-					$"Unknown {nameof(ConstraintResolutionBehavior)} value '{resolutionKind}'")
-			};
 
 		private static string RenderTruncateTables(IEnumerable<TableSchema> tables) =>
 			string.Join(Environment.NewLine,

--- a/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
+++ b/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
@@ -52,25 +52,54 @@ namespace Reseed.Generation.Cleanup
 				toClean.PartitionBy(o => !cleanupTarget.GetCustomScript(o.Value.Name, out _));
 
 			var persistentTables = rest.Concat(customClean).ToArray();
-			return new List<SqlScriptAction>(2)
+			var getDefaultIncomingRelations = ChooseIncomingRelationsGetter(
+				tables,
+				persistentTables,
+				cleanupMode.ConstraintBehavior);
+			var getCustomIncomingRelations = BuildIncomingRelationsGetter(persistentTables);
+			var shouldDropConstraints =
+				cleanupMode.ConstraintBehavior == ConstraintResolutionBehavior.DropConstraints;
+			var foreignKeys = shouldDropConstraints
+				? defaultClean
+					.SelectMany(o => getDefaultIncomingRelations(o.Value))
+					.Concat(customClean.SelectMany(o => getCustomIncomingRelations(o.Value)))
+					.ToArray()
+				: Array.Empty<Relation<TableSchema>>();
+
+			var cleanupScripts = new List<SqlScriptAction>(4)
+				.AddScriptWhen(
+					() => new SqlScriptAction("Drop Foreign Keys",
+						RenderDropForeignKeys(foreignKeys, false)),
+					foreignKeys.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Delete from tables",
 						string.Join(Environment.NewLine + Environment.NewLine,
 							RenderDeleteFromTables(
 								FilterGraph(orderedTables, defaultClean),
-								ChooseIncomingRelationsGetter(
-									tables,
-									persistentTables,
-									cleanupMode.ConstraintBehavior)))),
+								shouldDropConstraints
+									? GetNoIncomingRelations
+									: getDefaultIncomingRelations,
+								cleanupMode.ConstraintBehavior))),
 					defaultClean.Length > 0)
 				.AddScriptWhen(() => new SqlScriptAction("Custom cleanup scripts",
 						RenderCustomCleanupScripts(
 							customClean,
 							BuildCustomScriptGetter(cleanupTarget),
-							BuildIncomingRelationsGetter(persistentTables))),
+							shouldDropConstraints
+								? GetNoIncomingRelations
+								: getCustomIncomingRelations,
+							cleanupMode.ConstraintBehavior)),
 					customClean.Length > 0)
+				.AddScriptWhen(
+					() => new SqlScriptAction("Create Foreign Keys",
+						RenderCreateForeignKeys(foreignKeys)),
+					foreignKeys.Length > 0)
 				.WithNaturalOrder()
 				.ToArray();
+
+			return WrapDroppedConstraintCleanupInTransaction(
+				cleanupScripts,
+				shouldDropConstraints && foreignKeys.Length > 0);
 		}
 
 		private static IReadOnlyCollection<OrderedItem<SqlScriptAction>> RenderPreferTruncateScripts(
@@ -87,15 +116,34 @@ namespace Reseed.Generation.Cleanup
 			var (defaultClean, customClean) =
 				toClean.PartitionBy(o => !cleanupTarget.GetCustomScript(o.Value.Name, out _));
 
+			var shouldDropConstraints =
+				cleanupMode.ConstraintBehavior == ConstraintResolutionBehavior.DropConstraints;
 			var (toDelete, toTruncate) =
 				defaultClean.PartitionBy(o =>
 					cleanupMode.ShouldUseDelete(o.Value.Name) ||
 					o.Value.IsReferencedByIndexedView ||
-					getAllIncomingRelations(o.Value).Any());
+					(!shouldDropConstraints && getAllIncomingRelations(o.Value).Any()));
 
 			var persistentTables = rest.Concat(customClean).ToArray();
+			var getDeleteIncomingRelations = ChooseIncomingRelationsGetter(
+				tables,
+				persistentTables,
+				cleanupMode.ConstraintBehavior);
+			var getCustomIncomingRelations = BuildIncomingRelationsGetter(persistentTables);
+			var foreignKeys = shouldDropConstraints
+				? toTruncate
+					.Unordered()
+					.SelectMany(getAllIncomingRelations)
+					.Concat(toDelete.SelectMany(o => getDeleteIncomingRelations(o.Value)))
+					.Concat(customClean.SelectMany(o => getCustomIncomingRelations(o.Value)))
+					.ToArray()
+				: Array.Empty<Relation<TableSchema>>();
 
-			return new List<SqlScriptAction>(3)
+			var cleanupScripts = new List<SqlScriptAction>(5)
+				.AddScriptWhen(
+					() => new SqlScriptAction("Drop Foreign Keys",
+						RenderDropForeignKeys(foreignKeys, false)),
+					foreignKeys.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Truncate tables",
 						RenderTruncateTables(toTruncate.Unordered())),
@@ -104,20 +152,31 @@ namespace Reseed.Generation.Cleanup
 					() => new SqlScriptAction("Delete from tables",
 						RenderDeleteFromTables(
 							FilterGraph(orderedTables, toDelete),
-							ChooseIncomingRelationsGetter(
-								tables,
-								persistentTables,
-								cleanupMode.ConstraintBehavior))),
+							shouldDropConstraints
+								? GetNoIncomingRelations
+								: getDeleteIncomingRelations,
+							cleanupMode.ConstraintBehavior)),
 					toDelete.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Custom cleanup scripts",
 						RenderCustomCleanupScripts(
 							customClean,
 							BuildCustomScriptGetter(cleanupTarget),
-							BuildIncomingRelationsGetter(persistentTables))),
+							shouldDropConstraints
+								? GetNoIncomingRelations
+								: getCustomIncomingRelations,
+							cleanupMode.ConstraintBehavior)),
 					customClean.Length > 0)
+				.AddScriptWhen(
+					() => new SqlScriptAction("Create Foreign Keys",
+						RenderCreateForeignKeys(foreignKeys)),
+					foreignKeys.Length > 0)
 				.WithNaturalOrder()
 				.ToArray();
+
+			return WrapDroppedConstraintCleanupInTransaction(
+				cleanupScripts,
+				shouldDropConstraints && foreignKeys.Length > 0);
 		}
 
 		private static IReadOnlyCollection<OrderedItem<SqlScriptAction>> RenderTruncateScripts(
@@ -150,12 +209,24 @@ namespace Reseed.Generation.Cleanup
 					"Add these tables to the useDeleteForTables argument or use CleanupMode.PreferTruncate().");
 			}
 
-			var foreignKeys =
-				tablesToTruncate.SelectMany(getAllIncomingRelations).Distinct().ToArray();
-
 			var persistentTables = rest.Concat(customClean).ToArray();
+			var getDeleteIncomingRelations = ChooseIncomingRelationsGetter(
+				tables,
+				persistentTables,
+				cleanupMode.ConstraintBehavior);
+			var getCustomIncomingRelations = BuildIncomingRelationsGetter(persistentTables);
+			var shouldDropConstraints =
+				cleanupMode.ConstraintBehavior == ConstraintResolutionBehavior.DropConstraints;
+			var foreignKeys = tablesToTruncate
+				.SelectMany(getAllIncomingRelations)
+				.Concat(shouldDropConstraints
+					? toDelete
+						.SelectMany(o => getDeleteIncomingRelations(o.Value))
+						.Concat(customClean.SelectMany(o => getCustomIncomingRelations(o.Value)))
+					: Enumerable.Empty<Relation<TableSchema>>())
+				.ToArray();
 
-			return new List<SqlScriptAction>(5)
+			var cleanupScripts = new List<SqlScriptAction>(5)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Drop Foreign Keys",
 						RenderDropForeignKeys(foreignKeys, false)),
@@ -168,17 +239,20 @@ namespace Reseed.Generation.Cleanup
 					() => new SqlScriptAction("Delete from tables",
 						RenderDeleteFromTables(
 							FilterGraph(orderedTables, toDelete),
-							ChooseIncomingRelationsGetter(
-								tables,
-								persistentTables,
-								cleanupMode.ConstraintBehavior))),
+							shouldDropConstraints
+								? GetNoIncomingRelations
+								: getDeleteIncomingRelations,
+							cleanupMode.ConstraintBehavior)),
 					toDelete.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Custom cleanup scripts",
 						RenderCustomCleanupScripts(
 							customClean,
 							BuildCustomScriptGetter(cleanupTarget),
-							BuildIncomingRelationsGetter(persistentTables))),
+							shouldDropConstraints
+								? GetNoIncomingRelations
+								: getCustomIncomingRelations,
+							cleanupMode.ConstraintBehavior)),
 					customClean.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Create Foreign Keys",
@@ -186,6 +260,10 @@ namespace Reseed.Generation.Cleanup
 					foreignKeys.Length > 0)
 				.WithNaturalOrder()
 				.ToArray();
+
+			return WrapDroppedConstraintCleanupInTransaction(
+				cleanupScripts,
+				shouldDropConstraints && foreignKeys.Length > 0);
 		}
 
 		private static Func<TableSchema, Relation<TableSchema>[]> ChooseIncomingRelationsGetter(
@@ -196,6 +274,7 @@ namespace Reseed.Generation.Cleanup
 			{
 				ConstraintResolutionBehavior.OrderTables => BuildIncomingRelationsGetter(persistentTables),
 				ConstraintResolutionBehavior.DisableConstraints => BuildIncomingRelationsGetter(allTables),
+				ConstraintResolutionBehavior.DropConstraints => BuildIncomingRelationsGetter(allTables),
 				_ => throw new NotSupportedException(
 					$"Unknown {nameof(ConstraintResolutionBehavior)} value '{resolutionKind}'")
 			};
@@ -206,7 +285,8 @@ namespace Reseed.Generation.Cleanup
 
 		private static string RenderDeleteFromTables(
 			OrderedGraph<TableSchema> tables,
-			Func<TableSchema, Relation<TableSchema>[]> getIncomingRelations)
+			Func<TableSchema, Relation<TableSchema>[]> getIncomingRelations,
+			ConstraintResolutionBehavior constraintBehavior)
 		{
 			var scripts = MutualReferenceResolver.MergeChunks(
 				tables,
@@ -215,18 +295,23 @@ namespace Reseed.Generation.Cleanup
 					ts.Select(t => RenderCleanupTables(
 						new[] { t.Value },
 						getIncomingRelations(t.Value),
-						GetCleanupScript))),
+						GetCleanupScript,
+						constraintBehavior))),
 				ms =>
 				{
-					var foreignKeys = ms.Relations
-						.Concat(ms.Items.SelectMany(o => getIncomingRelations(o.Value)))
-						.Distinct()
-						.ToArray();
+					var foreignKeys =
+						constraintBehavior == ConstraintResolutionBehavior.DropConstraints
+							? Array.Empty<Relation<TableSchema>>()
+							: ms.Relations
+								.Concat(ms.Items.SelectMany(o => getIncomingRelations(o.Value)))
+								.Distinct()
+								.ToArray();
 
 					return RenderCleanupTables(
 						ms.Items.Order(),
 						foreignKeys,
-						GetCleanupScript);
+						GetCleanupScript,
+						constraintBehavior);
 				},
 				MutualGroupOrderMode.Min);
 
@@ -238,29 +323,85 @@ namespace Reseed.Generation.Cleanup
 		private static string RenderCustomCleanupScripts(
 			OrderedItem<TableSchema>[] tables,
 			Func<ObjectName, string> getCleanupScript,
-			Func<TableSchema, Relation<TableSchema>[]> getIncomingRelations) =>
+			Func<TableSchema, Relation<TableSchema>[]> getIncomingRelations,
+			ConstraintResolutionBehavior constraintBehavior) =>
 			string.Join(Environment.NewLine + Environment.NewLine,
 				tables.Order().Select(t =>
 					RenderCleanupTables(new[] { t },
 						getIncomingRelations(t),
-						getCleanupScript)));
+						getCleanupScript,
+						constraintBehavior)));
 
 		private static string RenderCleanupTables(
 			IEnumerable<TableSchema> tables,
 			IReadOnlyCollection<Relation<TableSchema>> foreignKeys,
-			Func<ObjectName, string> getCleanupScript)
+			Func<ObjectName, string> getCleanupScript,
+			ConstraintResolutionBehavior constraintBehavior)
 		{
-			var decoratedSeparator = foreignKeys.Any() ? Environment.NewLine : string.Empty;
-			var fkDecorator = new DisableForeignKeysDecorator(
-				foreignKeys
-					.Select(r => r.Map(t => t.Name))
-					.ToArray());
+			var cleanupScript = string.Join(
+				Environment.NewLine,
+				tables.Select(s => getCleanupScript(s.Name)));
+			if (foreignKeys.Count == 0)
+			{
+				return cleanupScript;
+			}
 
-			return string.Join(string.Empty,
-				decoratedSeparator,
-				fkDecorator.Decorate(string.Join(Environment.NewLine,
-					tables.Select(s => getCleanupScript(s.Name)))),
-				decoratedSeparator);
+			return constraintBehavior switch
+			{
+				ConstraintResolutionBehavior.OrderTables or
+					ConstraintResolutionBehavior.DisableConstraints =>
+					Environment.NewLine +
+					new DisableForeignKeysDecorator(
+							foreignKeys
+								.Select(r => r.Map(t => t.Name))
+								.ToArray())
+						.Decorate(cleanupScript) +
+					Environment.NewLine,
+				ConstraintResolutionBehavior.DropConstraints =>
+					throw new InvalidOperationException(
+						"DropConstraints must be resolved for the complete cleanup action."),
+				_ => throw new NotSupportedException(
+					$"Unknown {nameof(ConstraintResolutionBehavior)} value '{constraintBehavior}'")
+			};
+		}
+
+		private static IReadOnlyCollection<OrderedItem<SqlScriptAction>>
+			WrapDroppedConstraintCleanupInTransaction(
+				IReadOnlyCollection<OrderedItem<SqlScriptAction>> scripts,
+				bool shouldWrap)
+		{
+			if (!shouldWrap)
+			{
+				return scripts;
+			}
+
+			var cleanupScript = SqlScriptAction.Join(
+				"Cleanup with dropped constraints",
+				scripts);
+
+			return OrderedItem.OrderedCollection(
+				cleanupScript.Map(
+					script => $@"
+						|DECLARE @ReseedXactAbortWasOn bit =
+						|	CASE WHEN (16384 & @@OPTIONS) = 16384 THEN 1 ELSE 0 END;
+						|SET XACT_ABORT ON;
+						|BEGIN TRY
+						|	BEGIN TRANSACTION;
+						|
+						{script.WithMargin("\t", '|')}
+						|
+						|	COMMIT TRANSACTION;
+						|	IF @ReseedXactAbortWasOn = 0
+						|		SET XACT_ABORT OFF;
+						|END TRY
+						|BEGIN CATCH
+						|	IF @@TRANCOUNT > 0
+						|		ROLLBACK TRANSACTION;
+						|	IF @ReseedXactAbortWasOn = 0
+						|		SET XACT_ABORT OFF;
+						|	THROW;
+						|END CATCH"
+						.TrimMargin('|')));
 		}
 
 		private static OrderedGraph<TableSchema> FilterGraph(
@@ -290,6 +431,9 @@ namespace Reseed.Generation.Cleanup
 					? rs
 					: Array.Empty<Relation<TableSchema>>();
 		}
+
+		private static Relation<TableSchema>[] GetNoIncomingRelations(TableSchema _) =>
+			Array.Empty<Relation<TableSchema>>();
 
 		private static Func<ObjectName, string> BuildCustomScriptGetter(CleanupTarget target) =>
 			t => target.GetCustomScript(t, out var s)

--- a/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
+++ b/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
@@ -289,7 +289,7 @@ namespace Reseed.Generation.Cleanup
 				tables,
 				ts => string.Join(
 					Environment.NewLine,
-					ts.Select(t => RenderCleanupTables(
+					ts.Select(t => RenderCleanupWithDisabledForeignKeys(
 						new[] { t.Value },
 						getIncomingRelations(t.Value),
 						GetCleanupScript))),
@@ -303,7 +303,7 @@ namespace Reseed.Generation.Cleanup
 								.Distinct()
 								.ToArray();
 
-					return RenderCleanupTables(
+					return RenderCleanupWithDisabledForeignKeys(
 						ms.Items.Order(),
 						foreignKeys,
 						GetCleanupScript);
@@ -321,11 +321,11 @@ namespace Reseed.Generation.Cleanup
 			Func<TableSchema, Relation<TableSchema>[]> getIncomingRelations) =>
 			string.Join(Environment.NewLine + Environment.NewLine,
 				tables.Order().Select(t =>
-					RenderCleanupTables(new[] { t },
+					RenderCleanupWithDisabledForeignKeys(new[] { t },
 						getIncomingRelations(t),
 						getCleanupScript)));
 
-		private static string RenderCleanupTables(
+		private static string RenderCleanupWithDisabledForeignKeys(
 			IEnumerable<TableSchema> tables,
 			IReadOnlyCollection<Relation<TableSchema>> foreignKeys,
 			Func<ObjectName, string> getCleanupScript)

--- a/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
+++ b/src/Reseed/Generation/Cleanup/DeleteScriptRenderer.cs
@@ -87,8 +87,7 @@ namespace Reseed.Generation.Cleanup
 							BuildCustomScriptGetter(cleanupTarget),
 							shouldDropConstraints
 								? GetNoIncomingRelations
-								: getCustomIncomingRelations,
-							cleanupMode.ConstraintBehavior)),
+								: getCustomIncomingRelations)),
 					customClean.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Create Foreign Keys",
@@ -164,8 +163,7 @@ namespace Reseed.Generation.Cleanup
 							BuildCustomScriptGetter(cleanupTarget),
 							shouldDropConstraints
 								? GetNoIncomingRelations
-								: getCustomIncomingRelations,
-							cleanupMode.ConstraintBehavior)),
+								: getCustomIncomingRelations)),
 					customClean.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Create Foreign Keys",
@@ -251,8 +249,7 @@ namespace Reseed.Generation.Cleanup
 							BuildCustomScriptGetter(cleanupTarget),
 							shouldDropConstraints
 								? GetNoIncomingRelations
-								: getCustomIncomingRelations,
-							cleanupMode.ConstraintBehavior)),
+								: getCustomIncomingRelations)),
 					customClean.Length > 0)
 				.AddScriptWhen(
 					() => new SqlScriptAction("Create Foreign Keys",
@@ -295,8 +292,7 @@ namespace Reseed.Generation.Cleanup
 					ts.Select(t => RenderCleanupTables(
 						new[] { t.Value },
 						getIncomingRelations(t.Value),
-						GetCleanupScript,
-						constraintBehavior))),
+						GetCleanupScript))),
 				ms =>
 				{
 					var foreignKeys =
@@ -310,8 +306,7 @@ namespace Reseed.Generation.Cleanup
 					return RenderCleanupTables(
 						ms.Items.Order(),
 						foreignKeys,
-						GetCleanupScript,
-						constraintBehavior);
+						GetCleanupScript);
 				},
 				MutualGroupOrderMode.Min);
 
@@ -323,46 +318,29 @@ namespace Reseed.Generation.Cleanup
 		private static string RenderCustomCleanupScripts(
 			OrderedItem<TableSchema>[] tables,
 			Func<ObjectName, string> getCleanupScript,
-			Func<TableSchema, Relation<TableSchema>[]> getIncomingRelations,
-			ConstraintResolutionBehavior constraintBehavior) =>
+			Func<TableSchema, Relation<TableSchema>[]> getIncomingRelations) =>
 			string.Join(Environment.NewLine + Environment.NewLine,
 				tables.Order().Select(t =>
 					RenderCleanupTables(new[] { t },
 						getIncomingRelations(t),
-						getCleanupScript,
-						constraintBehavior)));
+						getCleanupScript)));
 
 		private static string RenderCleanupTables(
 			IEnumerable<TableSchema> tables,
 			IReadOnlyCollection<Relation<TableSchema>> foreignKeys,
-			Func<ObjectName, string> getCleanupScript,
-			ConstraintResolutionBehavior constraintBehavior)
+			Func<ObjectName, string> getCleanupScript)
 		{
-			var cleanupScript = string.Join(
-				Environment.NewLine,
-				tables.Select(s => getCleanupScript(s.Name)));
-			if (foreignKeys.Count == 0)
-			{
-				return cleanupScript;
-			}
+			var decoratedSeparator = foreignKeys.Any() ? Environment.NewLine : string.Empty;
+			var fkDecorator = new DisableForeignKeysDecorator(
+				foreignKeys
+					.Select(r => r.Map(t => t.Name))
+					.ToArray());
 
-			return constraintBehavior switch
-			{
-				ConstraintResolutionBehavior.OrderTables or
-					ConstraintResolutionBehavior.DisableConstraints =>
-					Environment.NewLine +
-					new DisableForeignKeysDecorator(
-							foreignKeys
-								.Select(r => r.Map(t => t.Name))
-								.ToArray())
-						.Decorate(cleanupScript) +
-					Environment.NewLine,
-				ConstraintResolutionBehavior.DropConstraints =>
-					throw new InvalidOperationException(
-						"DropConstraints must be resolved for the complete cleanup action."),
-				_ => throw new NotSupportedException(
-					$"Unknown {nameof(ConstraintResolutionBehavior)} value '{constraintBehavior}'")
-			};
+			return string.Join(string.Empty,
+				decoratedSeparator,
+				fkDecorator.Decorate(string.Join(Environment.NewLine,
+					tables.Select(s => getCleanupScript(s.Name)))),
+				decoratedSeparator);
 		}
 
 		private static IReadOnlyCollection<OrderedItem<SqlScriptAction>>

--- a/tests/Reseed.Tests.Integration/CleanupTests.cs
+++ b/tests/Reseed.Tests.Integration/CleanupTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
 using Reseed.Configuration;
 using Reseed.Configuration.Cleanup;
+using Reseed.Execution;
 using Reseed.Generation;
 using Reseed.Schema;
 using Reseed.Tests.Integration.Core;
@@ -70,6 +72,193 @@ namespace Reseed.Tests.Integration
 			Assert.That(
 				GetCleanupScript(actions),
 				Does.Contain("DELETE FROM [dbo].[User];"));
+		}
+
+		[Test]
+		public async Task ShouldDropConstraintsToPreferTruncateForeignKeyTables()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var sql = new SqlEngine(database.ConnectionString);
+			var reseeder = new Reseeder();
+
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.PreferTruncate(
+						constraintBehavior: ConstraintResolutionBehavior.DropConstraints),
+					CleanupTarget.Excluding())));
+
+			var cleanupScript = GetCleanupScript(actions);
+			Assert.Multiple(() =>
+			{
+				Assert.That(cleanupScript, Does.Contain(
+					"ALTER TABLE [dbo].[Child]"));
+				Assert.That(cleanupScript, Does.Contain(
+					"CONSTRAINT IF EXISTS [FK_Child_Parent]"));
+				Assert.That(cleanupScript, Does.Contain(
+					"CONSTRAINT [FK_Child_Parent]"));
+				Assert.That(cleanupScript, Does.Contain(
+					"TRUNCATE TABLE [dbo].[Parent];"));
+				Assert.That(cleanupScript, Does.Contain(
+					"TRUNCATE TABLE [dbo].[Child];"));
+				Assert.That(cleanupScript, Does.Not.Contain("DELETE FROM"));
+			});
+
+			await using var connection = new SqlConnection(database.ConnectionString);
+			await connection.OpenAsync();
+			await using var command = connection.CreateCommand();
+
+			command.CommandText = "SET XACT_ABORT OFF;";
+			await command.ExecuteNonQueryAsync();
+			reseeder.Execute(connection, actions.RestoreData);
+			Assert.That(await GetXactAbortOption(command), Is.Zero);
+
+			command.CommandText = "SET XACT_ABORT ON;";
+			await command.ExecuteNonQueryAsync();
+			reseeder.Execute(connection, actions.RestoreData);
+			Assert.That(await GetXactAbortOption(command), Is.EqualTo(1));
+
+			Assert.That(
+				await CountForeignKey(sql),
+				Is.EqualTo(1));
+		}
+
+		[Test]
+		public async Task ShouldDropAndRecreateConstraintsForDelete()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var sql = new SqlEngine(database.ConnectionString);
+			var reseeder = new Reseeder();
+
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.Delete(ConstraintResolutionBehavior.DropConstraints),
+					CleanupTarget.Excluding())));
+
+			var cleanupScript = GetCleanupScript(actions);
+			Assert.Multiple(() =>
+			{
+				Assert.That(cleanupScript, Does.Contain(
+					"CONSTRAINT IF EXISTS [FK_Child_Parent]"));
+				Assert.That(cleanupScript, Does.Contain(
+					"CONSTRAINT [FK_Child_Parent]"));
+				Assert.That(cleanupScript, Does.Not.Contain("NOCHECK"));
+				Assert.That(cleanupScript, Does.Not.Contain("CHECK CONSTRAINT"));
+			});
+
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+
+			Assert.That(
+				await CountForeignKey(sql),
+				Is.EqualTo(1));
+		}
+
+		[Test]
+		public async Task ShouldPreferDeleteForIndexedViewWhenDroppingConstraints()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var reseeder = new Reseeder();
+
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.PreferTruncate(
+						constraintBehavior: ConstraintResolutionBehavior.DropConstraints),
+					CleanupTarget.Excluding())));
+
+			var cleanupScript = GetCleanupScript(actions);
+			Assert.Multiple(() =>
+			{
+				Assert.That(cleanupScript, Does.Contain("DELETE FROM [dbo].[User];"));
+				Assert.That(cleanupScript, Does.Not.Contain("TRUNCATE TABLE [dbo].[User];"));
+			});
+		}
+
+		[Test]
+		public async Task ShouldRecreateConstraintsAfterCustomCleanup()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var sql = new SqlEngine(database.ConnectionString);
+			var reseeder = new Reseeder();
+
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.Delete(ConstraintResolutionBehavior.DropConstraints),
+					CleanupTarget.Excluding(
+						customScripts: new[]
+						{
+							(
+								table: new ObjectName("Child"),
+								script: "DELETE FROM [dbo].[Child];")
+						}))));
+
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+
+			Assert.That(
+				await CountForeignKey(sql),
+				Is.EqualTo(1));
+		}
+
+		[Test]
+		public async Task ShouldDropConstraintsForMutuallyReferencingTables()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var sql = new SqlEngine(database.ConnectionString);
+			var reseeder = new Reseeder();
+
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.Delete(ConstraintResolutionBehavior.DropConstraints),
+					CleanupTarget.Excluding())));
+
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+			reseeder.Execute(database.ConnectionString, actions.RestoreData);
+
+			Assert.That(
+				await sql.ExecuteScalarAsync<int>(
+					"SELECT COUNT(1) FROM sys.foreign_keys " +
+					"WHERE [name] IN ('FK_Left_Right', 'FK_Right_Left') " +
+					"AND [is_disabled] = 0"),
+				Is.EqualTo(2));
+		}
+
+		[Test]
+		public async Task ShouldRollbackWhenConstraintCannotBeRecreated()
+		{
+			await using var database = await Conventional.CreateConventionalDatabase(this);
+			var sql = new SqlEngine(database.ConnectionString);
+			var reseeder = new Reseeder();
+
+			var actions = reseeder.Generate(
+				database.ConnectionString,
+				new CleanupOnlySeedMode(CleanupDefinition.Script(
+					CleanupMode.Delete(ConstraintResolutionBehavior.DropConstraints),
+					CleanupTarget.Including(c =>
+						c.IncludeTables(new ObjectName("Parent"))))));
+
+			Assert.Throws<SeedActionExecutionException>(() =>
+				reseeder.Execute(database.ConnectionString, actions.RestoreData));
+
+			Assert.That(await CountForeignKey(sql), Is.EqualTo(1));
+			Assert.That(
+				await sql.ExecuteScalarAsync<int>("SELECT COUNT(1) FROM [dbo].[Parent]"),
+				Is.EqualTo(1));
+		}
+
+		private static Task<int> CountForeignKey(SqlEngine sql) =>
+			sql.ExecuteScalarAsync<int>(
+				"SELECT COUNT(1) FROM sys.foreign_keys " +
+				"WHERE [name] = 'FK_Child_Parent' AND [is_disabled] = 0");
+
+		private static async Task<int> GetXactAbortOption(SqlCommand command)
+		{
+			command.CommandText =
+				"SELECT CASE WHEN (16384 & @@OPTIONS) = 16384 THEN 1 ELSE 0 END";
+			return (int)await command.ExecuteScalarAsync();
 		}
 
 		private static string GetCleanupScript(SeedActions actions) =>

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/04_ShouldDropConstraintsToPreferTruncateForeignKeyTables.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/04_ShouldDropConstraintsToPreferTruncateForeignKeyTables.sql
@@ -1,0 +1,13 @@
+CREATE TABLE [dbo].[Parent] (
+	Id int NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE [dbo].[Child] (
+	Id int NOT NULL PRIMARY KEY,
+	ParentId int NOT NULL,
+	CONSTRAINT [FK_Child_Parent]
+		FOREIGN KEY ([ParentId]) REFERENCES [dbo].[Parent] ([Id])
+);
+
+INSERT INTO [dbo].[Parent] ([Id]) VALUES (1);
+INSERT INTO [dbo].[Child] ([Id], [ParentId]) VALUES (1, 1);

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/05_ShouldDropAndRecreateConstraintsForDelete.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/05_ShouldDropAndRecreateConstraintsForDelete.sql
@@ -1,0 +1,13 @@
+CREATE TABLE [dbo].[Parent] (
+	Id int NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE [dbo].[Child] (
+	Id int NOT NULL PRIMARY KEY,
+	ParentId int NOT NULL,
+	CONSTRAINT [FK_Child_Parent]
+		FOREIGN KEY ([ParentId]) REFERENCES [dbo].[Parent] ([Id])
+);
+
+INSERT INTO [dbo].[Parent] ([Id]) VALUES (1);
+INSERT INTO [dbo].[Child] ([Id], [ParentId]) VALUES (1, 1);

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/06_ShouldPreferDeleteForIndexedViewWhenDroppingConstraints.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/06_ShouldPreferDeleteForIndexedViewWhenDroppingConstraints.sql
@@ -1,0 +1,22 @@
+CREATE TABLE [User] (
+	Id int NOT NULL IDENTITY(1, 1) PRIMARY KEY,
+	FirstName nvarchar(100) NOT NULL,
+	LastName nvarchar(100) NOT NULL,
+	Age int NULL
+);
+
+INSERT INTO [User] (FirstName, LastName, Age)
+VALUES (N'John', N'Doe', 30);
+
+GO
+
+CREATE VIEW [dbo].[viUser]
+WITH SCHEMABINDING
+AS
+	SELECT [Id], [FirstName], [LastName]
+	FROM [dbo].[User];
+
+GO
+
+CREATE UNIQUE CLUSTERED INDEX [IX_viUser_Id]
+	ON [dbo].[viUser] ([Id]);

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/07_ShouldRecreateConstraintsAfterCustomCleanup.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/07_ShouldRecreateConstraintsAfterCustomCleanup.sql
@@ -1,0 +1,13 @@
+CREATE TABLE [dbo].[Parent] (
+	Id int NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE [dbo].[Child] (
+	Id int NOT NULL PRIMARY KEY,
+	ParentId int NOT NULL,
+	CONSTRAINT [FK_Child_Parent]
+		FOREIGN KEY ([ParentId]) REFERENCES [dbo].[Parent] ([Id])
+);
+
+INSERT INTO [dbo].[Parent] ([Id]) VALUES (1);
+INSERT INTO [dbo].[Child] ([Id], [ParentId]) VALUES (1, 1);

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/08_ShouldDropConstraintsForMutuallyReferencingTables.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/08_ShouldDropConstraintsForMutuallyReferencingTables.sql
@@ -1,0 +1,21 @@
+CREATE TABLE [dbo].[Left] (
+	Id int NOT NULL PRIMARY KEY,
+	RightId int NULL
+);
+
+CREATE TABLE [dbo].[Right] (
+	Id int NOT NULL PRIMARY KEY,
+	LeftId int NULL
+);
+
+ALTER TABLE [dbo].[Left]
+	ADD CONSTRAINT [FK_Left_Right]
+	FOREIGN KEY ([RightId]) REFERENCES [dbo].[Right] ([Id]);
+
+ALTER TABLE [dbo].[Right]
+	ADD CONSTRAINT [FK_Right_Left]
+	FOREIGN KEY ([LeftId]) REFERENCES [dbo].[Left] ([Id]);
+
+INSERT INTO [dbo].[Left] ([Id]) VALUES (1);
+INSERT INTO [dbo].[Right] ([Id], [LeftId]) VALUES (1, 1);
+UPDATE [dbo].[Left] SET [RightId] = 1 WHERE [Id] = 1;

--- a/tests/Reseed.Tests.Integration/Data/CleanupTests/09_ShouldRollbackWhenConstraintCannotBeRecreated.sql
+++ b/tests/Reseed.Tests.Integration/Data/CleanupTests/09_ShouldRollbackWhenConstraintCannotBeRecreated.sql
@@ -1,0 +1,13 @@
+CREATE TABLE [dbo].[Parent] (
+	Id int NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE [dbo].[Child] (
+	Id int NOT NULL PRIMARY KEY,
+	ParentId int NOT NULL,
+	CONSTRAINT [FK_Child_Parent]
+		FOREIGN KEY ([ParentId]) REFERENCES [dbo].[Parent] ([Id])
+);
+
+INSERT INTO [dbo].[Parent] ([Id]) VALUES (1);
+INSERT INTO [dbo].[Child] ([Id], [ParentId]) VALUES (1, 1);

--- a/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
+++ b/tests/Reseed.Tests.Integration/Reseed.Tests.Integration.csproj
@@ -31,6 +31,24 @@
     <None Update="Data\CleanupTests\03_ShouldUseDeleteIfExplicitlyRequested.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Data\CleanupTests\04_ShouldDropConstraintsToPreferTruncateForeignKeyTables.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\CleanupTests\05_ShouldDropAndRecreateConstraintsForDelete.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\CleanupTests\06_ShouldPreferDeleteForIndexedViewWhenDroppingConstraints.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\CleanupTests\07_ShouldRecreateConstraintsAfterCustomCleanup.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\CleanupTests\08_ShouldDropConstraintsForMutuallyReferencingTables.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\CleanupTests\09_ShouldRollbackWhenConstraintCannotBeRecreated.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Data\SingleTableTests\04_ShouldInsert_RowVersionMissing.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- add ConstraintResolutionBehavior.DropConstraints
- allow PreferTruncate to truncate FK-related tables while retaining DELETE for indexed views
- wrap FK drop, cleanup, and recreation in a transaction with rollback and session option restoration
- document the new behavior and cover FKs, custom cleanup, cycles, indexed views, and failure rollback

## Tests
- dotnet test tests\Reseed.Tests.Integration\Reseed.Tests.Integration.csproj --no-restore --nologo --filter FullyQualifiedName~CleanupTests
- dotnet build Reseed.sln --no-restore --nologo